### PR TITLE
FIX-001: remove dead duplicate redirect for /trompe-loeil-architectural-illusions

### DIFF
--- a/_ttp/FIX-001/evidence.json
+++ b/_ttp/FIX-001/evidence.json
@@ -12,6 +12,6 @@
   "duplicate_check": "PASS — 0 duplicate sources after cleanup",
   "loop_check": "PASS",
   "build": "PASS",
-  "commit": "PENDING",
-  "pr_url": "PENDING"
+  "commit": "e07e6c3",
+  "pr_url": "https://github.com/rayrich01/misha-website/pull/8"
 }


### PR DESCRIPTION
## Summary
- GSC reported 404 for `/trompe-loeil-architectural-illusions`
- Investigation found the working redirect (line 21 → `/services/trompe-loeil-architectural-illusions`) was already in place
- A dead duplicate entry on line 30 (→ `/trompe-loeil-houston`) never fired (Next.js uses first match) and would have created a two-hop chain
- Removed the dead duplicate; no functional change to live redirect behavior

## Checks
- Duplicate sources: **PASS** (0 after cleanup)
- Loop/chain check: **PASS**
- Build: **PASS**

## Evidence
`_ttp/FIX-001/evidence.json`

## Test plan
- [ ] Verify Vercel preview 301s `/trompe-loeil-architectural-illusions` → `/services/trompe-loeil-architectural-illusions`
- [ ] After merge: Request re-indexing in GSC

🤖 Generated with [Claude Code](https://claude.com/claude-code)