### PR TITLE
DISP-001: ultra-wide display fix — misha-website

### DIFF
--- a/_ttp/DISP-001/evidence-misha-website.json
+++ b/_ttp/DISP-001/evidence-misha-website.json
@@ -1,0 +1,14 @@
+{
+  "package": "DISP-001",
+  "site": "misha-website",
+  "date": "2026-03-11T00:00:00Z",
+  "type": "display-fix",
+  "change": "Added max-w-screen-2xl mx-auto w-full wrapper in root layout.tsx",
+  "max_width_px": 1536,
+  "tailwind_class": "max-w-screen-2xl",
+  "existing_constraint_found": false,
+  "hero_fixed_heights_found": "none",
+  "build": "PASS",
+  "commit": "",
+  "pr_url": ""
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,7 +72,6 @@ export default function RootLayout({
   height="0" width="0" style="display:none;visibility:hidden"></iframe>
 ` }} />
 {/* End Google Tag Manager (noscript) */}
-        <Header />
 {/* Google Tag Manager */}
 <script dangerouslySetInnerHTML={{ __html: `
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -82,8 +81,11 @@ export default function RootLayout({
   })(window,document,'script','dataLayer','GTM-T8WG6SX9');
 ` }} />
 {/* End Google Tag Manager */}
-        <main>{children}</main>
-        <Footer />
+        <div className="max-w-screen-2xl mx-auto w-full">
+          <Header />
+          <main>{children}</main>
+          <Footer />
+        </div>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- Adds `max-w-screen-2xl` (1536px) wrapper div in root `layout.tsx`
- Constrains content column to 1536px centered on displays wider than 1920px
- Fixes layout distortion on ultra-wide and 4K/5K displays

## Details
- Wrapper encloses Header, main content, and Footer
- Header/Footer internal `max-w-7xl` constraints remain unchanged
- No fixed pixel hero heights found — no additional changes needed
- Build: PASS

## Evidence
`_ttp/DISP-001/evidence-misha-website.json`

## Test plan
- [ ] Test on standard 1920px display — no visual change expected
- [ ] Test on 2560px+ width (Chrome DevTools device emulator)
- [ ] Verify content centered and capped at 1536px
- [ ] Verify backgrounds still bleed edge-to-edge where intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)