### PR TITLE
Remove Calendly links, add phone number (#11)

### DIFF
--- a/src/app/consult/page.tsx
+++ b/src/app/consult/page.tsx
@@ -1,21 +1,36 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'Schedule a Consultation | Misha Creations Houston',
+  title: 'Contact Misha | Misha Creations Houston',
   description:
-    'Book a complimentary consultation with Misha Creations. We will visit your Houston home, study the light and architecture, and show you what is possible.',
+    'Get in touch with Misha Creations. Call (281) 650-0500 to discuss your project, or submit an inquiry online.',
 }
 
 export default function ConsultPage() {
   return (
-    <section className="pt-20 min-h-screen bg-cream">
-      <iframe
-        src="https://calendly.com/mishacreations/30min"
-        width="100%"
-        height="100%"
-        className="min-h-[calc(100vh-80px)] border-0"
-        title="Schedule a consultation with Misha Creations"
-      />
+    <section className="pt-32 pb-20 min-h-screen bg-cream">
+      <div className="max-w-2xl mx-auto px-5 text-center">
+        <h1 className="font-display text-4xl md:text-5xl text-dark mb-6">
+          Let&apos;s Talk About Your Project
+        </h1>
+        <p className="font-body text-lg text-charcoal/80 leading-relaxed mb-10">
+          The best way to get started is to give Misha a call. She&apos;ll listen to your
+          vision, answer your questions, and arrange a time to visit your home.
+        </p>
+        <a
+          href="tel:+12816500500"
+          className="inline-block bg-gold text-dark text-sm uppercase tracking-widest px-10 py-4 rounded-full hover:bg-gold/90 transition-colors font-body font-medium mb-6"
+        >
+          Call (281) 650-0500
+        </a>
+        <p className="font-body text-sm text-charcoal/60">
+          Prefer to write?{' '}
+          <Link href="/inquire" className="text-gold hover:text-bronze transition-colors underline">
+            Submit an inquiry
+          </Link>
+        </p>
+      </div>
     </section>
   )
 }

--- a/src/app/decorative-painting-houston/page.tsx
+++ b/src/app/decorative-painting-houston/page.tsx
@@ -112,12 +112,12 @@ export default async function DecorativePaintingHoustonPage() {
             murals, custom faux finishes, and decorative treatments that transform
             architecture into art.
           </p>
-          <Link
-            href="/consult"
+          <a
+            href="tel:+12816500500"
             className="inline-block bg-gold text-dark text-sm uppercase tracking-widest px-10 py-4 rounded-full hover:bg-gold/90 transition-colors font-body font-medium"
           >
-            Schedule a Consultation
-          </Link>
+            Call (281) 650-0500
+          </a>
         </div>
       </section>
 

--- a/src/app/inquire/page.tsx
+++ b/src/app/inquire/page.tsx
@@ -116,8 +116,9 @@ export default function InquirePage() {
         <p className="font-body text-charcoal leading-relaxed mb-10">
           Tell Misha about your project, vision, location you live, a realistic timeline
           as well as any questions you may have and she will respond within 48 hours.
-          You can also schedule a free consultative call directly with Misha or reach
-          out to her via phone or text.
+          You can also call Misha directly at{' '}
+          <a href="tel:+12816500500" className="text-gold hover:text-bronze transition-colors">(281) 650-0500</a>{' '}
+          or reach out via text.
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-5">
@@ -287,12 +288,12 @@ export default function InquirePage() {
             (281) 650-0500
           </a>
           <div>
-            <Link
-              href="/consult"
+            <a
+              href="tel:+12816500500"
               className="inline-block font-body text-xs uppercase tracking-widest text-charcoal/60 border border-sand px-7 py-3 hover:bg-gold/10 transition-colors"
             >
-              Or Schedule a Consultation
-            </Link>
+              Or Call (281) 650-0500
+            </a>
           </div>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -113,12 +113,12 @@ export default async function HomePage() {
           <p className="font-body text-lg md:text-xl text-white/90 mb-10 max-w-2xl leading-relaxed">
             {subheadline}
           </p>
-          <Link
-            href="/consult"
+          <a
+            href="tel:+12816500500"
             className="inline-block bg-cream text-charcoal text-sm uppercase tracking-widest px-10 py-4 rounded-full hover:bg-sand transition-colors font-body font-medium shadow-xl"
           >
-            Schedule Free Consultation
-          </Link>
+            Call (281) 650-0500
+          </a>
         </div>
       </section>
 

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -142,12 +142,12 @@ export default async function PieceDetailPage({ params }: PageProps) {
                 <p className="font-body text-sm text-charcoal/70 leading-relaxed mb-5">
                   Every project is one-of-a-kind, customized to your home&apos;s architecture and light. Misha can create something similar tailored to your space.
                 </p>
-                <Link
-                  href={`/consult`}
+                <a
+                  href="tel:+12816500500"
                   className="block text-center bg-gold text-dark text-xs uppercase tracking-widest font-body font-medium px-6 py-3 rounded-full hover:bg-gold/90 transition-colors"
                 >
-                  Request a Consultation
-                </Link>
+                  Call (281) 650-0500
+                </a>
                 <Link
                   href={`/inquire${finish ? `?finish=${finish.categoryId}` : ''}`}
                   className="block text-center mt-3 font-body text-xs text-gold hover:text-bronze transition-colors"

--- a/src/components/CtaSection.tsx
+++ b/src/components/CtaSection.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link'
-
 interface Props {
   headline?: string
   body?: string
@@ -16,12 +14,12 @@ export function CtaSection({
         <p className="font-body text-lg leading-relaxed text-cream/85 mb-10">
           {body}
         </p>
-        <Link
-          href="/consult"
+        <a
+          href="tel:+12816500500"
           className="inline-block bg-gold text-dark text-sm uppercase tracking-widest px-10 py-4 rounded-full hover:bg-gold/90 transition-colors font-body font-medium"
         >
-          Schedule Your Consultation
-        </Link>
+          Call (281) 650-0500
+        </a>
       </div>
     </section>
   )

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -67,12 +67,12 @@ export function Footer() {
             >
               Contact
             </Link>
-            <Link
-              href="/consult"
+            <a
+              href="tel:+12816500500"
               className="inline-block mt-3 bg-gold text-dark text-xs uppercase tracking-widest px-6 py-2.5 rounded-full hover:bg-gold/90 transition-colors font-body"
             >
-              Schedule Consultation
-            </Link>
+              Call (281) 650-0500
+            </a>
           </div>
         </div>
         <div className="border-t border-cream/10 mt-12 pt-8 flex flex-col sm:flex-row items-center justify-between gap-3">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -67,12 +67,12 @@ export function Header() {
           >
             Contact
           </Link>
-          <Link
-            href="/consult"
+          <a
+            href="tel:+12816500500"
             className="bg-charcoal text-cream text-xs uppercase tracking-widest px-6 py-2.5 rounded-full hover:bg-dark transition-colors"
           >
-            Schedule a Call With Misha
-          </Link>
+            Call (281) 650-0500
+          </a>
         </div>
 
         {/* Mobile hamburger */}
@@ -135,13 +135,13 @@ export function Header() {
           >
             Contact
           </Link>
-          <Link
-            href="/consult"
+          <a
+            href="tel:+12816500500"
             className="block mt-4 text-center bg-charcoal text-cream text-xs uppercase tracking-widest px-6 py-3 rounded-full"
             onClick={() => setOpen(false)}
           >
-            Schedule a Call With Misha
-          </Link>
+            Call (281) 650-0500
+          </a>
         </div>
       )}
     </header>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -247,7 +247,7 @@ export const COPY = {
   tagline: "Houston's premier decorative finishes artist",
   phone: '(281) 650-0500',
   email: 'misha@mishacreations.com',
-  calendlyUrl: 'https://calendly.com/mishacreations/30min',
+  phoneHref: 'tel:+12816500500',
   address: { city: 'Houston', state: 'TX', country: 'US' },
   socialProof: ['River Oaks', 'Tanglewood', 'Memorial', 'West University', 'Bellaire', 'The Woodlands'],
   social: {


### PR DESCRIPTION
## Summary
- Removes all Calendly booking/scheduling links site-wide
- Replaces with Misha's phone number **(281) 650-0500** as `tel:` links
- Phone number now in: Header nav, Footer, hero CTA, CtaSection, consult page, decorative painting page, inquire page, portfolio detail pages

## Files changed (9)
- `src/lib/constants.ts` — `calendlyUrl` → `phoneHref`
- `src/components/Header.tsx` — desktop + mobile "Schedule a Call" → phone link
- `src/components/Footer.tsx` — "Schedule Consultation" → phone link
- `src/components/CtaSection.tsx` — CTA button → phone link
- `src/app/consult/page.tsx` — Calendly embed → phone CTA page
- 4 page files — CTA buttons converted to `tel:` links

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)