### PR TITLE
Remove Schedule a Call buttons, show phone number (#14)

### DIFF
--- a/src/app/decorative-painting-houston/page.tsx
+++ b/src/app/decorative-painting-houston/page.tsx
@@ -116,7 +116,7 @@ export default async function DecorativePaintingHoustonPage() {
             href="tel:+12816500500"
             className="inline-block bg-gold text-ink text-sm uppercase tracking-widest px-10 py-4 rounded-full hover:bg-gold/90 transition-colors font-body font-medium"
           >
-            Schedule a Consultation
+            Call (281) 650-0500
           </a>
         </div>
       </section>

--- a/src/app/inquire/page.tsx
+++ b/src/app/inquire/page.tsx
@@ -292,7 +292,7 @@ export default function InquirePage() {
               href="tel:+12816500500"
               className="inline-block font-body text-xs uppercase tracking-widest text-mist/60 border border-muted/30 px-7 py-3 hover:bg-gold/10 transition-colors"
             >
-              Or Schedule a Consultation
+              Or Call (281) 650-0500
             </a>
           </div>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -71,7 +71,7 @@ export function Header() {
             href="tel:+12816500500"
             className="bg-cream text-ink text-xs uppercase tracking-widest px-6 py-2.5 rounded-full hover:bg-cream/90 transition-colors"
           >
-            Schedule a Call With Misha
+            Call (281) 650-0500
           </a>
         </div>
 
@@ -140,7 +140,7 @@ export function Header() {
             className="block mt-4 text-center bg-cream text-ink text-xs uppercase tracking-widest px-6 py-3 rounded-full"
             onClick={() => setOpen(false)}
           >
-            Schedule a Call With Misha
+            Call (281) 650-0500
           </a>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Replaces 4 remaining "Schedule a Call With Misha" / "Schedule a Consultation" button labels with "Call (281) 650-0500"
- Header (desktop + mobile nav), decorative-painting-houston hero, inquire page footer
- Links already pointed to `tel:+12816500500` — only the display text was stale

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)