### PR TITLE
seo: add robots.txt Disallow for preview/api/index (MC-LIVE-SEO-008B)

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -5,6 +5,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
+      disallow: ['/preview/', '/api/', '/index'],
     },
     sitemap: 'https://mishacreations.com/sitemap.xml',
     host: 'https://mishacreations.com',


### PR DESCRIPTION
Defense-in-depth: Disallow /preview/, /api/, /index. All 24 approved routes unaffected.