### PR TITLE
seo: form submission dataLayer event (MC-LIVE-SEO-008C)

### DIFF
--- a/src/app/inquire/page.tsx
+++ b/src/app/inquire/page.tsx
@@ -78,13 +78,16 @@ export default function InquirePage() {
       }
 
       // Push lead event to GTM dataLayer for GA4 measurement
-      if (typeof window !== 'undefined' && (window as Record<string, unknown>).dataLayer) {
-        ;(window as { dataLayer: Record<string, unknown>[] }).dataLayer.push({
-          event: 'generate_lead',
-          form_id: 'inquire',
-          project_type: payload.projectType || '',
-          room_type: payload.roomType || '',
-        })
+      if (typeof window !== 'undefined') {
+        const w = window as unknown as { dataLayer?: Record<string, unknown>[] }
+        if (w.dataLayer) {
+          w.dataLayer.push({
+            event: 'generate_lead',
+            form_id: 'inquire',
+            project_type: payload.projectType || '',
+            room_type: payload.roomType || '',
+          })
+        }
       }
 
       setSubmitted(true)


### PR DESCRIPTION
Adds generate_lead event to GTM dataLayer on /inquire form success. Ray must configure GTM trigger/tag + GA4.