### PR TITLE
perf: cap image width at 1920px — CWV LCP fix (MC-LIVE-SEO-012B)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,10 @@ const nextConfig: NextConfig = {
   images: {
     loader: 'custom',
     loaderFile: './src/lib/sanity-image-loader.ts',
+    /* Cap largest device breakpoint at 1920 — removes 2048/3840 defaults
+       that cause oversized image requests on Sanity CDN (MC-LIVE-SEO-012B) */
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/lib/sanity-image-loader.ts
+++ b/src/lib/sanity-image-loader.ts
@@ -1,3 +1,8 @@
+/* Cap max requested width to prevent oversized image delivery from Sanity CDN.
+   Removes the w=3840 / w=2048 requests that were sending 4K images to mobile screens.
+   See MC-LIVE-SEO-006A + MC-LIVE-SEO-012B for context. */
+const MAX_WIDTH = 1920
+
 export default function sanityImageLoader({
   src,
   width,
@@ -8,7 +13,7 @@ export default function sanityImageLoader({
   quality?: number
 }) {
   const url = new URL(src)
-  url.searchParams.set('w', width.toString())
+  url.searchParams.set('w', Math.min(width, MAX_WIDTH).toString())
   url.searchParams.set('q', (quality || 75).toString())
   if (!url.searchParams.has('auto')) url.searchParams.set('auto', 'format')
   return url.toString()


### PR DESCRIPTION
Caps max image request at 1920px (was 3840px). Two-layer fix: deviceSizes config + loader cap. ~50-75% mobile payload reduction. No layout/content changes.