### PR TITLE
Add CMS query layer for Sanity page content

### DIFF
--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -159,3 +159,213 @@ export async function getHomepageHero(): Promise<PortfolioPiece | null> {
     | order(displayOrder asc) [0] { ${PIECE_FIELDS} }
   `)
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   CMS Page Content — replaces constants.ts hardcoded content
+   ═══════════════════════════════════════════════════════════════ */
+
+// ── Interfaces ──
+
+export interface CmsServicePage {
+  _id: string
+  slug: { current: string }
+  categoryId: string
+  title: string
+  h1: string
+  cardDescription: string
+  sortOrder: number
+  seo: { metaTitle: string; metaDescription: string }
+  intro: { heading: string; paragraphs: string[] }
+  process: { heading: string; steps: { name: string; desc: string }[] }
+  trust: { heading: string; points: string[] }
+  extraFaqs: { question: string; answer: string }[]
+  relatedServices: { slug: string; label: string }[]
+  areaContext: string
+}
+
+export interface CmsAreaPage {
+  _id: string
+  slug: { current: string }
+  name: string
+  sortOrder: number
+  seo: { metaTitle: string; metaDescription: string }
+  h1: string
+  description: string
+  featuredCategories: string[]
+  categoryOffset: number
+  popularFinishes: string[]
+  faqAnswers: { serve: string; cost: string; popular: string }
+  extraFaqs: { question: string; answer: string }[]
+  nearbyAreas: { slug: string; name: string }[]
+  trustPoints: string[]
+}
+
+export interface CmsServicesHubPage {
+  seo: { metaTitle: string; metaDescription: string }
+  heroHeadline: string
+  heroSubtext: string
+  introText: string
+  trustHeading: string
+  trustPoints: string[]
+  processHeading: string
+  hubFaqs: { question: string; answer: string }[]
+  ctaHeadline: string
+  ctaBody: string
+}
+
+export interface CmsProcessPage {
+  seo: { metaTitle: string; metaDescription: string }
+  heroHeadline: string
+  heroSubtext: string
+  introHeading: string
+  introText: string
+  aboutHeading: string
+  aboutParagraphs: string[]
+  processSteps: { step: string; name: string; desc: string }[]
+  faqs: { question: string; answer: string }[]
+  ctaHeadline: string
+  ctaBody: string
+}
+
+export interface CmsSiteGlobals {
+  siteName: string
+  tagline: string
+  phone: string
+  phoneHref: string
+  email: string
+  address: { city: string; state: string; country: string }
+  socialProofNeighborhoods: string[]
+  social: { instagram: string; facebook: string; pinterest: string; googleMaps: string }
+  processSteps: { step: string; name: string; desc: string }[]
+  inquireRoomTypes: string[]
+  inquireTimeframes: { value: string; label: string }[]
+}
+
+// ── Queries ──
+
+const SERVICE_PAGE_FIELDS = `
+  _id, slug, categoryId, title, h1, cardDescription, sortOrder,
+  seo { metaTitle, metaDescription },
+  intro { heading, paragraphs },
+  process { heading, steps[] { name, desc } },
+  trust { heading, points },
+  extraFaqs[] { question, answer },
+  relatedServices[] { slug, label },
+  areaContext
+`
+
+const AREA_PAGE_FIELDS = `
+  _id, slug, name, sortOrder,
+  seo { metaTitle, metaDescription },
+  h1, description,
+  featuredCategories, categoryOffset, popularFinishes,
+  faqAnswers { serve, cost, popular },
+  extraFaqs[] { question, answer },
+  nearbyAreas[] { slug, name },
+  trustPoints
+`
+
+/** Single service page by slug */
+export async function getServicePage(slug: string): Promise<CmsServicePage | null> {
+  return sanityClient.fetch(`
+    *[_type == "servicePage" && slug.current == $slug][0] { ${SERVICE_PAGE_FIELDS} }
+  `, { slug })
+}
+
+/** All service pages (for hub page and navigation) */
+export async function getAllServicePages(): Promise<CmsServicePage[]> {
+  return sanityClient.fetch(`
+    *[_type == "servicePage"] | order(sortOrder asc) { ${SERVICE_PAGE_FIELDS} }
+  `)
+}
+
+/** All service page slugs (for generateStaticParams) */
+export async function getAllServiceSlugs(): Promise<string[]> {
+  return sanityClient.fetch(`
+    *[_type == "servicePage"].slug.current
+  `)
+}
+
+/** Single area page by slug */
+export async function getAreaPage(slug: string): Promise<CmsAreaPage | null> {
+  return sanityClient.fetch(`
+    *[_type == "areaPage" && slug.current == $slug][0] { ${AREA_PAGE_FIELDS} }
+  `, { slug })
+}
+
+/** All area pages (for navigation and cross-links) */
+export async function getAllAreaPages(): Promise<CmsAreaPage[]> {
+  return sanityClient.fetch(`
+    *[_type == "areaPage"] | order(sortOrder asc) { ${AREA_PAGE_FIELDS} }
+  `)
+}
+
+/** All area page slugs (for generateStaticParams) */
+export async function getAllAreaSlugs(): Promise<string[]> {
+  return sanityClient.fetch(`
+    *[_type == "areaPage"].slug.current
+  `)
+}
+
+/** Services hub page singleton */
+export async function getServicesHubPage(): Promise<CmsServicesHubPage | null> {
+  return sanityClient.fetch(`
+    *[_type == "servicesHubPage" && _id == "servicesHubPage"][0] {
+      seo { metaTitle, metaDescription },
+      heroHeadline, heroSubtext, introText,
+      trustHeading, trustPoints, processHeading,
+      hubFaqs[] { question, answer },
+      ctaHeadline, ctaBody
+    }
+  `)
+}
+
+/** Process page singleton */
+export async function getProcessPage(): Promise<CmsProcessPage | null> {
+  return sanityClient.fetch(`
+    *[_type == "processPage" && _id == "processPage"][0] {
+      seo { metaTitle, metaDescription },
+      heroHeadline, heroSubtext,
+      introHeading, introText,
+      aboutHeading, aboutParagraphs,
+      processSteps[] { step, name, desc },
+      faqs[] { question, answer },
+      ctaHeadline, ctaBody
+    }
+  `)
+}
+
+/** Site globals singleton */
+export async function getSiteGlobals(): Promise<CmsSiteGlobals | null> {
+  return sanityClient.fetch(`
+    *[_type == "siteGlobals" && _id == "siteGlobals"][0] {
+      siteName, tagline, phone, phoneHref, email,
+      address { city, state, country },
+      socialProofNeighborhoods,
+      social { instagram, facebook, pinterest, googleMaps },
+      processSteps[] { step, name, desc },
+      inquireRoomTypes,
+      inquireTimeframes[] { value, label }
+    }
+  `)
+}
+
+/** Navigation data — lightweight fetch for layout */
+export async function getNavData(): Promise<{
+  services: { slug: string; title: string; categoryId: string }[]
+  areas: { slug: string; name: string }[]
+}> {
+  const [services, areas] = await Promise.all([
+    sanityClient.fetch<{ slug: string; title: string; categoryId: string }[]>(`
+      *[_type == "servicePage"] | order(sortOrder asc) {
+        "slug": slug.current, title, categoryId
+      }
+    `),
+    sanityClient.fetch<{ slug: string; name: string }[]>(`
+      *[_type == "areaPage"] | order(sortOrder asc) {
+        "slug": slug.current, name
+      }
+    `),
+  ])
+  return { services, areas }
+}


### PR DESCRIPTION
## Summary
- 10 new GROQ query functions for fetching page content from Sanity
- 5 new TypeScript interfaces matching seeded CMS document shapes
- Lightweight getNavData() for Header/Footer navigation
- No frontend changes — queries ready for Phase 4 wiring

## Test plan
- [ ] Build passes
- [ ] Queries return valid data from Sanity (seeded in studio-site PR #16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)