### PR TITLE
Wire service and area pages to Sanity CMS

### DIFF
--- a/src/app/areas/[slug]/page.tsx
+++ b/src/app/areas/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { NEIGHBORHOOD_MAP, NEIGHBORHOODS, NEIGHBORHOOD_CONTENT, FINISH_SURFACES } from '@/lib/constants'
-import { getPiecesByCategories, getMishaSelectPieces } from '@/lib/queries'
+import { getPiecesByCategories, getMishaSelectPieces, getAreaPage, getAllAreaSlugs, getAllServicePages } from '@/lib/queries'
 import { SanityImage } from '@/components/SanityImage'
 import { FaqAccordion } from '@/components/FaqAccordion'
 import { CtaSection } from '@/components/CtaSection'
@@ -15,23 +15,29 @@ interface PageProps {
 }
 
 export async function generateStaticParams() {
+  const cmsSlugs = await getAllAreaSlugs().catch(() => [])
+  if (cmsSlugs.length > 0) return cmsSlugs.map((s) => ({ slug: s }))
   return NEIGHBORHOODS.map((n) => ({ slug: n.slug }))
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params
+  const cms = await getAreaPage(slug).catch(() => null)
   const hood = NEIGHBORHOOD_MAP[slug]
-  if (!hood) return notFound()
+  if (!cms && !hood) return notFound()
+
+  const metaTitle = cms ? cms.seo.metaTitle : hood!.metaTitle
+  const metaDescription = cms ? cms.seo.metaDescription : hood!.metaDescription
 
   return {
-    title: hood.metaTitle,
-    description: hood.metaDescription,
+    title: metaTitle,
+    description: metaDescription,
     alternates: {
       canonical: `https://mishacreations.com/areas/${slug}`,
     },
     openGraph: {
-      title: hood.metaTitle,
-      description: hood.metaDescription,
+      title: metaTitle,
+      description: metaDescription,
       url: `https://mishacreations.com/areas/${slug}`,
     },
   }
@@ -39,24 +45,45 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function AreaPage({ params }: PageProps) {
   const { slug } = await params
+  const cms = await getAreaPage(slug).catch(() => null)
   const hood = NEIGHBORHOOD_MAP[slug]
-  if (!hood) return notFound()
+  if (!cms && !hood) return notFound()
 
-  const content = NEIGHBORHOOD_CONTENT[slug]
+  const name = cms?.name || hood!.name
+  const h1 = cms?.h1 || hood!.h1
+
+  // Use CMS content if available, fall back to constants
+  const content = cms ? {
+    description: cms.description,
+    featuredCategories: cms.featuredCategories as [string, string],
+    categoryOffset: cms.categoryOffset,
+    popularFinishes: cms.popularFinishes,
+    faqAnswers: cms.faqAnswers,
+    extraFaqs: cms.extraFaqs,
+    nearbyAreas: cms.nearbyAreas,
+    trustPoints: cms.trustPoints,
+  } : NEIGHBORHOOD_CONTENT[slug] || null
+
   const pieces = content
     ? await getPiecesByCategories(content.featuredCategories, 2, content.categoryOffset)
     : (await getMishaSelectPieces(4)).slice(0, 4)
 
+  // Fetch service pages from CMS for the services grid, fall back to constants
+  const cmsServices = await getAllServicePages().catch(() => [])
+  const serviceList = cmsServices.length > 0
+    ? cmsServices.map((s) => ({ slug: s.slug.current, title: s.title }))
+    : FINISH_SURFACES.map((f) => ({ slug: f.slug, title: f.title }))
+
   const baseFaqs = content
     ? [
-        { question: `Does Misha Creations serve ${hood.name}?`, answer: content.faqAnswers.serve },
-        { question: `How much does decorative painting cost in ${hood.name}?`, answer: content.faqAnswers.cost },
-        { question: `What decorative finishes are popular in ${hood.name}?`, answer: content.faqAnswers.popular },
+        { question: `Does Misha Creations serve ${name}?`, answer: content.faqAnswers.serve },
+        { question: `How much does decorative painting cost in ${name}?`, answer: content.faqAnswers.cost },
+        { question: `What decorative finishes are popular in ${name}?`, answer: content.faqAnswers.popular },
       ]
     : [
-        { question: `Does Misha Creations serve ${hood.name}?`, answer: `Yes! Misha has been serving ${hood.name} homeowners for over 25 years with luxury decorative finishes, wall murals, and Venetian plaster. She personally visits your home for every consultation.` },
-        { question: `How much does decorative painting cost in ${hood.name}?`, answer: `Every project is customized to your tastes and priced based on scope, surface area, and finish complexity. Misha provides a detailed, no-obligation estimate after an in-home consultation.` },
-        { question: `What decorative finishes are popular in ${hood.name}?`, answer: `${hood.name} homeowners often choose Venetian plaster for entry halls, custom wall murals for dining rooms, and decorative ceiling treatments for living areas. Misha tailors every finish to complement your home's architecture.` },
+        { question: `Does Misha Creations serve ${name}?`, answer: `Yes! Misha has been serving ${name} homeowners for over 25 years with luxury decorative finishes, wall murals, and Venetian plaster. She personally visits your home for every consultation.` },
+        { question: `How much does decorative painting cost in ${name}?`, answer: `Every project is customized to your tastes and priced based on scope, surface area, and finish complexity. Misha provides a detailed, no-obligation estimate after an in-home consultation.` },
+        { question: `What decorative finishes are popular in ${name}?`, answer: `${name} homeowners often choose Venetian plaster for entry halls, custom wall murals for dining rooms, and decorative ceiling treatments for living areas. Misha tailors every finish to complement your home's architecture.` },
       ]
   const neighborhoodFaqs = content?.extraFaqs ? [...baseFaqs, ...content.extraFaqs] : baseFaqs
 
@@ -64,9 +91,9 @@ export default async function AreaPage({ params }: PageProps) {
     '@context': 'https://schema.org',
     '@type': ['LocalBusiness', 'VisualArtist'],
     name: 'Misha Creations',
-    description: `Luxury decorative finishes and wall murals in ${hood.name}, Houston`,
+    description: `Luxury decorative finishes and wall murals in ${name}, Houston`,
     url: `https://mishacreations.com/areas/${slug}`,
-    areaServed: { '@type': 'Neighborhood', name: hood.name },
+    areaServed: { '@type': 'Neighborhood', name: name },
   }
 
   return (
@@ -82,10 +109,10 @@ export default async function AreaPage({ params }: PageProps) {
         )}
         <div className="relative z-10 text-center px-5 max-w-4xl mx-auto pt-20">
           <h1 className="font-display text-[38px] leading-[48px] md:text-[54px] md:leading-[64px] text-white mb-4">
-            {hood.h1}
+            {h1}
           </h1>
           <p className="font-body text-lg text-white/85 max-w-2xl mx-auto">
-            Trusted by {hood.name} homeowners for over 25 years
+            Trusted by {name} homeowners for over 25 years
           </p>
         </div>
       </section>
@@ -104,7 +131,7 @@ export default async function AreaPage({ params }: PageProps) {
         <section className={`py-16 md:py-20 ${content ? 'bg-ink' : 'bg-warm'}`}>
           <div className="max-w-6xl mx-auto px-5">
             <h2 className="font-display text-3xl md:text-4xl text-center text-cream mb-12">
-              Work in {hood.name}
+              Work in {name}
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
               {pieces.map((piece) => (
@@ -114,7 +141,7 @@ export default async function AreaPage({ params }: PageProps) {
                     fill
                     sizes="(max-width: 640px) 100vw, 50vw"
                     className="object-cover"
-                    alt={piece.heroImage?.alt || `${piece.title} - decorative finish in ${hood.name} by Misha Creations`}
+                    alt={piece.heroImage?.alt || `${piece.title} - decorative finish in ${name} by Misha Creations`}
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
                   <div className="absolute bottom-0 left-0 right-0 p-5">
@@ -131,10 +158,10 @@ export default async function AreaPage({ params }: PageProps) {
       <section className="py-16 bg-warm">
         <div className="max-w-4xl mx-auto px-5 text-center">
           <h2 className="font-display text-3xl text-cream mb-8">
-            Services Available in {hood.name}
+            Services Available in {name}
           </h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {FINISH_SURFACES.map((f) => (
+            {serviceList.map((f) => (
               <Link
                 key={f.slug}
                 href={`/services/${f.slug}`}
@@ -152,7 +179,7 @@ export default async function AreaPage({ params }: PageProps) {
         <section className="py-16 md:py-20 bg-ink">
           <div className="max-w-3xl mx-auto px-5 text-center">
             <h2 className="font-display text-3xl md:text-4xl text-cream mb-8">
-              Why {hood.name} Homeowners Choose Misha
+              Why {name} Homeowners Choose Misha
             </h2>
             <ul className="space-y-3 text-left max-w-xl mx-auto">
               {content.trustPoints.map((point, i) => (
@@ -166,7 +193,7 @@ export default async function AreaPage({ params }: PageProps) {
         </section>
       )}
 
-      <FaqAccordion faqs={neighborhoodFaqs} heading={`${hood.name} FAQ`} />
+      <FaqAccordion faqs={neighborhoodFaqs} heading={`${name} FAQ`} />
 
       {/* Nearby Areas (004A / 013B) */}
       {content?.nearbyAreas && content.nearbyAreas.length > 0 && (
@@ -189,7 +216,7 @@ export default async function AreaPage({ params }: PageProps) {
       )}
 
       <CtaSection
-        headline={`Start Your ${hood.name} Project`}
+        headline={`Start Your ${name} Project`}
         body="Call today for a complimentary consultation. Misha will visit your home, study the light and architecture, and show you what is possible."
       />
     </>

--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { FINISH_MAP, FINISH_SURFACES, FINISH_DESCRIPTIONS, SERVICE_ENRICHMENT } from '@/lib/constants'
-import { getPiecesByCategory, getFinishCategory } from '@/lib/queries'
+import { getPiecesByCategory, getFinishCategory, getServicePage, getAllServiceSlugs } from '@/lib/queries'
 import { SanityImage } from '@/components/SanityImage'
 import { FaqAccordion } from '@/components/FaqAccordion'
 import { CtaSection } from '@/components/CtaSection'
@@ -15,23 +15,29 @@ interface PageProps {
 }
 
 export async function generateStaticParams() {
+  const cmsSlugs = await getAllServiceSlugs().catch(() => [])
+  if (cmsSlugs.length > 0) return cmsSlugs.map((s) => ({ slug: s }))
   return FINISH_SURFACES.map((f) => ({ slug: f.slug }))
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params
-  const finish = FINISH_MAP[slug]
+  const cms = await getServicePage(slug).catch(() => null)
+  const finish = cms || FINISH_MAP[slug]
   if (!finish) return notFound()
 
+  const metaTitle = cms ? cms.seo.metaTitle : (finish as typeof FINISH_MAP[string]).metaTitle
+  const metaDescription = cms ? cms.seo.metaDescription : (finish as typeof FINISH_MAP[string]).metaDescription
+
   return {
-    title: finish.metaTitle,
-    description: finish.metaDescription,
+    title: metaTitle,
+    description: metaDescription,
     alternates: {
       canonical: `https://mishacreations.com/services/${slug}`,
     },
     openGraph: {
-      title: finish.metaTitle,
-      description: finish.metaDescription,
+      title: metaTitle,
+      description: metaDescription,
       url: `https://mishacreations.com/services/${slug}`,
     },
   }
@@ -39,34 +45,47 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ServicePage({ params }: PageProps) {
   const { slug } = await params
+  const cms = await getServicePage(slug).catch(() => null)
   const finish = FINISH_MAP[slug]
-  if (!finish) return notFound()
+  if (!cms && !finish) return notFound()
+
+  const title = cms?.title || finish?.title || ''
+  const h1 = cms?.h1 || finish?.h1 || ''
+  const categoryId = cms?.categoryId || finish?.categoryId || ''
 
   const [pieces, category] = await Promise.all([
-    getPiecesByCategory(finish.categoryId, 6),
-    getFinishCategory(finish.categoryId),
+    getPiecesByCategory(categoryId, 6),
+    getFinishCategory(categoryId),
   ])
 
   const heroImage = category?.heroImage || pieces[0]?.heroImage
   const description =
     category?.tradeDescription ||
     category?.shortDescription ||
-    FINISH_DESCRIPTIONS[finish.categoryId] ||
-    `Misha Creations brings 25+ years of expertise in ${finish.title.toLowerCase()} to Houston's most distinguished homes. Each project is customized to your tastes, designed to complement your architecture and capture the unique light of your space.`
+    FINISH_DESCRIPTIONS[categoryId] ||
+    `Misha Creations brings 25+ years of expertise in ${title.toLowerCase()} to Houston's most distinguished homes. Each project is customized to your tastes, designed to complement your architecture and capture the unique light of your space.`
 
-  const enrichment = SERVICE_ENRICHMENT[finish.categoryId]
+  // CMS enrichment takes priority, fall back to constants.ts
+  const enrichment = cms ? {
+    intro: cms.intro,
+    process: cms.process,
+    trust: cms.trust,
+    extraFaqs: cms.extraFaqs,
+    relatedServices: cms.relatedServices,
+    areaContext: cms.areaContext,
+  } : SERVICE_ENRICHMENT[categoryId] || null
 
   const baseFaqs = [
     {
-      question: `How much does ${finish.title.toLowerCase()} cost in Houston?`,
-      answer: `Every ${finish.title.toLowerCase()} project is customized to your tastes and priced based on scope, surface area, and complexity. Misha provides a detailed estimate after an in-home consultation where she studies your space, lighting, and vision.`,
+      question: `How much does ${title.toLowerCase()} cost in Houston?`,
+      answer: `Every ${title.toLowerCase()} project is customized to your tastes and priced based on scope, surface area, and complexity. Misha provides a detailed estimate after an in-home consultation where she studies your space, lighting, and vision.`,
     },
     {
-      question: `How long does a ${finish.title.toLowerCase()} project take?`,
+      question: `How long does a ${title.toLowerCase()} project take?`,
       answer: `Timeline depends on the scope and complexity of the work. Most projects take 1-3 weeks from design approval to completion. Misha coordinates around your schedule and provides a realistic timeline during the consultation.`,
     },
     {
-      question: `Do you provide samples before starting ${finish.title.toLowerCase()} work?`,
+      question: `Do you provide samples before starting ${title.toLowerCase()} work?`,
       answer: `Absolutely. Misha creates physical finish samples for your approval before any brushwork begins. You see and touch the exact finish that will be applied in your home. No surprises on install day.`,
     },
   ]
@@ -75,7 +94,7 @@ export default async function ServicePage({ params }: PageProps) {
   const serviceSchema = {
     '@context': 'https://schema.org',
     '@type': 'Service',
-    name: `${finish.title} Houston`,
+    name: `${title} Houston`,
     provider: {
       '@type': 'LocalBusiness',
       name: 'Misha Creations',
@@ -100,7 +119,7 @@ export default async function ServicePage({ params }: PageProps) {
         {!heroImage && <div className="absolute inset-0 bg-ink" />}
         <div className="relative z-10 text-center px-5 max-w-4xl mx-auto pt-20">
           <h1 className="font-display text-[38px] leading-[48px] md:text-[54px] md:leading-[64px] text-white mb-4">
-            {finish.h1}
+            {h1}
           </h1>
           <p className="font-body text-lg text-white/85 max-w-2xl mx-auto">
             By Misha Creations &middot; 25+ Years of Artistic Excellence
@@ -158,7 +177,7 @@ export default async function ServicePage({ params }: PageProps) {
         <section className="py-16 md:py-20 bg-ink">
           <div className="max-w-7xl mx-auto px-5">
             <h2 className="font-display text-3xl md:text-4xl text-center text-cream mb-12">
-              Featured {finish.title} Work
+              Featured {title} Work
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
               {pieces.map((piece) => (
@@ -168,7 +187,7 @@ export default async function ServicePage({ params }: PageProps) {
                     fill
                     sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                     className="object-cover"
-                    alt={piece.heroImage?.alt || `${piece.title} - ${finish.title} by Misha Creations Houston`}
+                    alt={piece.heroImage?.alt || `${piece.title} - ${title} by Misha Creations Houston`}
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
                   <div className="absolute bottom-0 left-0 right-0 p-5">
@@ -203,7 +222,7 @@ export default async function ServicePage({ params }: PageProps) {
         </section>
       )}
 
-      <FaqAccordion faqs={finishFaqs} heading={`${finish.title} FAQ`} />
+      <FaqAccordion faqs={finishFaqs} heading={`${title} FAQ`} />
 
       {/* Related Services — enriched pages only (003A / 002C) */}
       {enrichment && enrichment.relatedServices.length > 0 && (
@@ -232,7 +251,7 @@ export default async function ServicePage({ params }: PageProps) {
       )}
 
       <CtaSection
-        headline={`Start Your ${finish.title} Project`}
+        headline={`Start Your ${title} Project`}
         body="Call today for a complimentary consultation. Misha will visit your home, study the light and architecture, and show you what is possible."
       />
     </>


### PR DESCRIPTION
## Summary
- Service detail pages now fetch from Sanity `servicePage` documents first, fall back to constants.ts
- Area pages now fetch from Sanity `areaPage` documents first, fall back to constants.ts
- `generateStaticParams` and `generateMetadata` both use CMS data when available
- Zero visual changes — CMS content is verbatim copy of constants.ts
- Safe rollback: if Sanity fetch fails, pages render from constants.ts

## Test plan
- [ ] All 8 service pages render correctly
- [ ] All 6 area pages render correctly
- [ ] SEO meta tags match current values
- [ ] FAQ sections display correctly
- [ ] Edit a service page in Sanity Studio and verify it updates within 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)