### PR TITLE
Wire services hub, process, Header, Footer to Sanity CMS

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Great_Vibes, Cormorant_Garamond, Jost } from 'next/font/google'
 import './globals.css'
 import { Header } from '@/components/Header'
 import { Footer } from '@/components/Footer'
+import { getNavData } from '@/lib/queries'
 
 const greatVibes = Great_Vibes({
   weight: '400',
@@ -56,11 +57,16 @@ export const metadata: Metadata = {
   },
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  // Fetch nav data from CMS — falls back to constants inside Header/Footer if this fails
+  const nav = await getNavData().catch(() => ({ services: [], areas: [] }))
+  const navServices = nav.services.map((s) => ({ slug: s.slug, title: s.title }))
+  const navAreas = nav.areas.map((a) => ({ slug: a.slug, name: a.name }))
+
   return (
     <html lang="en">
       <body
@@ -82,9 +88,9 @@ export default function RootLayout({
 ` }} />
 {/* End Google Tag Manager */}
         <div className="max-w-screen-2xl mx-auto w-full">
-          <Header />
+          <Header services={navServices} areas={navAreas} />
           <main>{children}</main>
-          <Footer />
+          <Footer services={navServices} areas={navAreas} />
         </div>
       </body>
     </html>

--- a/src/app/process/page.tsx
+++ b/src/app/process/page.tsx
@@ -1,50 +1,71 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { PROCESS_STEPS, FINISH_SURFACES, NEIGHBORHOODS, COPY } from '@/lib/constants'
+import { getProcessPage, getAllServicePages, getAllAreaPages, getSiteGlobals } from '@/lib/queries'
 import { FaqAccordion } from '@/components/FaqAccordion'
 import { CtaSection } from '@/components/CtaSection'
 import { JsonLd } from '@/components/JsonLd'
 
-export const metadata: Metadata = {
-  title: 'How Misha Works | Your Decorative Painting Process',
-  description:
-    'From first call to final reveal — learn how Misha Creations transforms Houston luxury homes with 25+ years of decorative painting expertise. Complimentary in-home consultation. Physical samples before work begins.',
-  alternates: {
-    canonical: 'https://mishacreations.com/process',
-  },
-  openGraph: {
-    title: 'How Misha Works | Your Decorative Painting Process | Misha Creations',
-    description:
-      'From first call to final reveal — learn how Misha transforms Houston luxury homes with decorative painting.',
-    url: 'https://mishacreations.com/process',
-  },
+export const revalidate = 60
+
+export async function generateMetadata(): Promise<Metadata> {
+  const cms = await getProcessPage().catch(() => null)
+  const metaTitle = cms?.seo?.metaTitle || 'How Misha Works | Your Decorative Painting Process'
+  const metaDescription = cms?.seo?.metaDescription || 'From first call to final reveal — learn how Misha Creations transforms Houston luxury homes with 25+ years of decorative painting expertise. Complimentary in-home consultation. Physical samples before work begins.'
+
+  return {
+    title: metaTitle,
+    description: metaDescription,
+    alternates: { canonical: 'https://mishacreations.com/process' },
+    openGraph: {
+      title: cms?.seo?.metaTitle || 'How Misha Works | Your Decorative Painting Process | Misha Creations',
+      description: 'From first call to final reveal — learn how Misha transforms Houston luxury homes with decorative painting.',
+      url: 'https://mishacreations.com/process',
+    },
+  }
 }
 
-const processFaqs = [
-  {
-    question: 'How long does the process take?',
-    answer:
-      'Most projects take 1-3 weeks from design approval to completion. The timeline depends on scope and complexity. Misha coordinates around your schedule and provides a realistic timeline during the consultation.',
-  },
-  {
-    question: 'Is the consultation really free?',
-    answer:
-      'Yes. The in-home consultation is complimentary with no obligation. Misha visits your home to study the space, discuss your vision, and provide a detailed estimate.',
-  },
-  {
-    question: 'Does Misha do the work herself?',
-    answer:
-      'Yes. Every decorative finish is hand-applied by Misha personally. She does not subcontract her artistry.',
-  },
-]
+export default async function ProcessPage() {
+  const [cms, cmsServices, cmsAreas, globals] = await Promise.all([
+    getProcessPage().catch(() => null),
+    getAllServicePages().catch(() => []),
+    getAllAreaPages().catch(() => []),
+    getSiteGlobals().catch(() => null),
+  ])
 
-export default function ProcessPage() {
+  const processSteps = cms?.processSteps || globals?.processSteps || PROCESS_STEPS
+  const phone = globals?.phone || COPY.phone
+  const phoneHref = globals?.phoneHref || COPY.phoneHref
+
+  const services = cmsServices.length > 0
+    ? cmsServices.map((s) => ({ slug: s.slug.current, title: s.title }))
+    : FINISH_SURFACES.map((f) => ({ slug: f.slug, title: f.title }))
+
+  const areas = cmsAreas.length > 0
+    ? cmsAreas.map((a) => ({ slug: a.slug.current, name: a.name }))
+    : NEIGHBORHOODS.map((n) => ({ slug: n.slug, name: n.name }))
+
+  const processFaqs = cms?.faqs || [
+    {
+      question: 'How long does the process take?',
+      answer: 'Most projects take 1-3 weeks from design approval to completion. The timeline depends on scope and complexity. Misha coordinates around your schedule and provides a realistic timeline during the consultation.',
+    },
+    {
+      question: 'Is the consultation really free?',
+      answer: 'Yes. The in-home consultation is complimentary with no obligation. Misha visits your home to study the space, discuss your vision, and provide a detailed estimate.',
+    },
+    {
+      question: 'Does Misha do the work herself?',
+      answer: 'Yes. Every decorative finish is hand-applied by Misha personally. She does not subcontract her artistry.',
+    },
+  ]
+
   const howToSchema = {
     '@context': 'https://schema.org',
     '@type': 'HowTo',
     name: 'How to Work with Misha Creations for Decorative Painting',
     description: 'The step-by-step process for commissioning decorative painting from Misha Creations in Houston.',
-    step: PROCESS_STEPS.map((s, i) => ({
+    step: processSteps.map((s, i) => ({
       '@type': 'HowToStep',
       position: i + 1,
       name: s.name,
@@ -60,10 +81,10 @@ export default function ProcessPage() {
       <section className="bg-ink pt-32 pb-16 md:pt-40 md:pb-20">
         <div className="max-w-4xl mx-auto px-5 text-center">
           <h1 className="font-display text-[42px] md:text-[58px] text-cream mb-4">
-            Your Decorative Painting Process
+            {cms?.heroHeadline || 'Your Decorative Painting Process'}
           </h1>
           <p className="font-body text-lg text-mist max-w-2xl mx-auto">
-            From first call to final reveal
+            {cms?.heroSubtext || 'From first call to final reveal'}
           </p>
         </div>
       </section>
@@ -72,14 +93,18 @@ export default function ProcessPage() {
       <section className="py-16 md:py-20 bg-warm">
         <div className="max-w-3xl mx-auto px-5">
           <h2 className="font-display text-3xl md:text-4xl text-center text-cream mb-8">
-            From First Call to Final Reveal
+            {cms?.introHeading || 'From First Call to Final Reveal'}
           </h2>
           <p className="font-body text-lg leading-relaxed text-mist mb-6">
-            Every project begins with a conversation. Whether you call{' '}
-            <a href={COPY.phoneHref} className="text-gold hover:text-goldf transition-colors">{COPY.phone}</a>{' '}
-            or{' '}
-            <Link href="/inquire" className="text-gold hover:text-goldf transition-colors">submit an inquiry</Link>
-            , Misha responds within 24 hours. From there, the process is personal, consultative, and grounded in 25+ years of decorative painting expertise in Houston.
+            {cms?.introText || (
+              <>
+                Every project begins with a conversation. Whether you call{' '}
+                <a href={phoneHref} className="text-gold hover:text-goldf transition-colors">{phone}</a>{' '}
+                or{' '}
+                <Link href="/inquire" className="text-gold hover:text-goldf transition-colors">submit an inquiry</Link>
+                , Misha responds within 24 hours. From there, the process is personal, consultative, and grounded in 25+ years of decorative painting expertise in Houston.
+              </>
+            )}
           </p>
         </div>
       </section>
@@ -88,7 +113,7 @@ export default function ProcessPage() {
       <section className="py-16 md:py-24 bg-ink">
         <div className="max-w-3xl mx-auto px-5">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            {PROCESS_STEPS.map((step) => (
+            {processSteps.map((step) => (
               <div key={step.step} className="border border-muted/30 rounded-lg p-6">
                 <p className="font-body text-xs uppercase tracking-widest text-gold mb-2">Step {step.step}</p>
                 <h2 className="font-editorial text-xl text-cream mb-3">{step.name}</h2>
@@ -103,20 +128,28 @@ export default function ProcessPage() {
       <section className="py-16 md:py-20 bg-warm">
         <div className="max-w-3xl mx-auto px-5">
           <h2 className="font-display text-3xl md:text-4xl text-center text-cream mb-8">
-            About Misha
+            {cms?.aboutHeading || 'About Misha'}
           </h2>
-          <p className="font-body text-lg leading-relaxed text-mist mb-6">
-            Misha has over 25 years of experience as a decorative painting artist in Houston. She trained at the Buon Fresco School of Venetian Plastering in Washington D.C. and Nicola Vigini Studios. Her work spans private estates to the Houston Zoo.
-          </p>
-          <p className="font-body text-mist leading-relaxed mb-6">
-            She serves Houston&apos;s finest neighborhoods including{' '}
-            {NEIGHBORHOODS.map((n, i) => (
-              <span key={n.slug}>
-                <Link href={`/areas/${n.slug}`} className="text-gold hover:text-goldf transition-colors">{n.name}</Link>
-                {i < NEIGHBORHOODS.length - 1 ? ', ' : '.'}
-              </span>
-            ))}
-          </p>
+          {cms?.aboutParagraphs ? (
+            cms.aboutParagraphs.map((p, i) => (
+              <p key={i} className="font-body text-lg leading-relaxed text-mist mb-6 last:mb-0">{p}</p>
+            ))
+          ) : (
+            <>
+              <p className="font-body text-lg leading-relaxed text-mist mb-6">
+                Misha has over 25 years of experience as a decorative painting artist in Houston. She trained at the Buon Fresco School of Venetian Plastering in Washington D.C. and Nicola Vigini Studios. Her work spans private estates to the Houston Zoo.
+              </p>
+              <p className="font-body text-mist leading-relaxed mb-6">
+                She serves Houston&apos;s finest neighborhoods including{' '}
+                {areas.map((a, i) => (
+                  <span key={a.slug}>
+                    <Link href={`/areas/${a.slug}`} className="text-gold hover:text-goldf transition-colors">{a.name}</Link>
+                    {i < areas.length - 1 ? ', ' : '.'}
+                  </span>
+                ))}
+              </p>
+            </>
+          )}
         </div>
       </section>
 
@@ -125,7 +158,7 @@ export default function ProcessPage() {
         <div className="max-w-3xl mx-auto px-5 text-center">
           <h2 className="font-display text-3xl text-cream mb-8">Services</h2>
           <div className="flex flex-wrap justify-center gap-3">
-            {FINISH_SURFACES.map((f) => (
+            {services.map((f) => (
               <Link
                 key={f.slug}
                 href={`/services/${f.slug}`}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,49 +1,63 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { FINISH_SURFACES, SERVICE_CARD_DESCRIPTIONS, SERVICES_HUB_FAQS, PROCESS_STEPS, COPY } from '@/lib/constants'
-import { getPiecesByCategory } from '@/lib/queries'
+import { getPiecesByCategory, getServicesHubPage, getAllServicePages, getSiteGlobals } from '@/lib/queries'
 import { SanityImage } from '@/components/SanityImage'
 import { CtaSection } from '@/components/CtaSection'
 import { FaqAccordion } from '@/components/FaqAccordion'
 import { JsonLd } from '@/components/JsonLd'
 
-export const metadata: Metadata = {
-  title: 'Decorative Painting Services Houston | Murals, Plaster & Custom Finishes | Misha Creations',
-  description: 'Explore 8 luxury decorative painting services from Houston\'s premier artist. Venetian plaster, wall murals, trompe l\'oeil, decorative ceilings, faux finishes, and more. 25+ years serving River Oaks, Memorial, and Tanglewood.',
-  alternates: {
-    canonical: 'https://mishacreations.com/services',
-  },
-  openGraph: {
-    title: 'Decorative Painting Services Houston | Murals, Plaster & Custom Finishes | Misha Creations',
-    description: 'Explore 8 luxury decorative painting services from Houston\'s premier artist. Venetian plaster, wall murals, trompe l\'oeil, decorative ceilings, faux finishes, and more.',
-    url: 'https://mishacreations.com/services',
-  },
-}
-
 export const revalidate = 60
 
+export async function generateMetadata(): Promise<Metadata> {
+  const hub = await getServicesHubPage().catch(() => null)
+  const metaTitle = hub?.seo?.metaTitle || 'Decorative Painting Services Houston | Murals, Plaster & Custom Finishes | Misha Creations'
+  const metaDescription = hub?.seo?.metaDescription || 'Explore 8 luxury decorative painting services from Houston\'s premier artist. Venetian plaster, wall murals, trompe l\'oeil, decorative ceilings, faux finishes, and more. 25+ years serving River Oaks, Memorial, and Tanglewood.'
+
+  return {
+    title: metaTitle,
+    description: metaDescription,
+    alternates: { canonical: 'https://mishacreations.com/services' },
+    openGraph: { title: metaTitle, description: metaDescription, url: 'https://mishacreations.com/services' },
+  }
+}
+
 export default async function ServicesPage() {
+  const [hub, cmsServices, globals] = await Promise.all([
+    getServicesHubPage().catch(() => null),
+    getAllServicePages().catch(() => []),
+    getSiteGlobals().catch(() => null),
+  ])
+
+  // Use CMS service pages if available, fall back to constants
+  const services = cmsServices.length > 0
+    ? cmsServices.map((s) => ({ slug: s.slug.current, categoryId: s.categoryId, title: s.title, cardDescription: s.cardDescription }))
+    : FINISH_SURFACES.map((f) => ({ slug: f.slug, categoryId: f.categoryId, title: f.title, cardDescription: SERVICE_CARD_DESCRIPTIONS[f.categoryId] || '' }))
+
+  const processSteps = globals?.processSteps || PROCESS_STEPS
+  const hubFaqs = hub?.hubFaqs || SERVICES_HUB_FAQS
+  const trustPoints = hub?.trustPoints || [
+    '25+ years of museum-quality artistry in Houston',
+    'Every finish hand-applied by the artist personally',
+    'Complimentary in-home consultation',
+    'Serving River Oaks, Memorial, Tanglewood, West University, The Woodlands, and Bellaire',
+  ]
+  const socialProof = globals?.socialProofNeighborhoods || [...COPY.socialProof]
+
   // Fetch one hero piece per category for the cards
   const categoryPieces = await Promise.all(
-    FINISH_SURFACES.map(async (f) => {
-      const pieces = await getPiecesByCategory(f.categoryId, 1)
-      return { finish: f, heroImage: pieces[0]?.heroImage }
+    services.map(async (s) => {
+      const pieces = await getPiecesByCategory(s.categoryId, 1)
+      return { service: s, heroImage: pieces[0]?.heroImage }
     })
   )
 
   const serviceSchema = {
     '@context': 'https://schema.org',
     '@type': 'Service',
-    provider: {
-      '@type': 'LocalBusiness',
-      name: 'Misha Creations',
-    },
-    serviceType: FINISH_SURFACES.map((f) => f.title),
-    areaServed: {
-      '@type': 'City',
-      name: 'Houston',
-      containedInPlace: { '@type': 'State', name: 'Texas' },
-    },
+    provider: { '@type': 'LocalBusiness', name: 'Misha Creations' },
+    serviceType: services.map((s) => s.title),
+    areaServed: { '@type': 'City', name: 'Houston', containedInPlace: { '@type': 'State', name: 'Texas' } },
   }
 
   return (
@@ -54,34 +68,34 @@ export default async function ServicesPage() {
       <section className="relative min-h-[50vh] flex items-center justify-center bg-ink">
         <div className="relative z-10 text-center px-5 max-w-4xl mx-auto pt-20">
           <h1 className="font-display text-[42px] leading-[52px] md:text-[58px] md:leading-[68px] text-cream mb-4">
-            Decorative Painting Services in Houston
+            {hub?.heroHeadline || 'Decorative Painting Services in Houston'}
           </h1>
           <p className="font-body text-lg text-mist max-w-2xl mx-auto">
-            Museum-quality artistry for Houston&apos;s most distinguished homes. 25+ years of artistic excellence.
+            {hub?.heroSubtext || "Museum-quality artistry for Houston's most distinguished homes. 25+ years of artistic excellence."}
           </p>
         </div>
       </section>
 
-      {/* Hub Introduction (003B) */}
+      {/* Hub Introduction */}
       <section className="py-12 md:py-16 bg-warm">
         <div className="max-w-3xl mx-auto px-5 text-center">
           <p className="font-body text-lg leading-relaxed text-mist">
-            Misha Creations offers 8 luxury decorative painting services for Houston&apos;s most distinguished homes. With 25+ years of museum-quality artistry, Misha hand-applies every finish personally &mdash; from Venetian lime plaster and wall murals to trompe l&apos;oeil, decorative ceilings, faux finishes, and more. Each project begins with a complimentary in-home consultation where Misha studies your space, light, and vision.
+            {hub?.introText || "Misha Creations offers 8 luxury decorative painting services for Houston's most distinguished homes. With 25+ years of museum-quality artistry, Misha hand-applies every finish personally — from Venetian lime plaster and wall murals to trompe l'oeil, decorative ceilings, faux finishes, and more. Each project begins with a complimentary in-home consultation where Misha studies your space, light, and vision."}
           </p>
         </div>
       </section>
 
-      {/* Service Cards with Descriptions (003B) */}
+      {/* Service Cards */}
       <section className="py-16 md:py-24 bg-ink">
         <div className="max-w-7xl mx-auto px-5">
           <h2 className="font-display text-3xl md:text-4xl text-center text-cream mb-12">
-            Our 8 Luxury Decorative Painting Services
+            Our {services.length} Luxury Decorative Painting Services
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            {categoryPieces.map(({ finish, heroImage }) => (
+            {categoryPieces.map(({ service, heroImage }) => (
               <Link
-                key={finish.slug}
-                href={`/services/${finish.slug}`}
+                key={service.slug}
+                href={`/services/${service.slug}`}
                 className="group relative aspect-[3/4] rounded-lg overflow-hidden shadow-md"
               >
                 {heroImage && (
@@ -95,9 +109,9 @@ export default async function ServicesPage() {
                 {!heroImage && <div className="absolute inset-0 bg-ink" />}
                 <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
                 <div className="absolute bottom-0 left-0 right-0 p-5">
-                  <h3 className="font-editorial text-lg text-white">{finish.title}</h3>
-                  {SERVICE_CARD_DESCRIPTIONS[finish.categoryId] && (
-                    <p className="font-body text-sm text-white/70 mt-1">{SERVICE_CARD_DESCRIPTIONS[finish.categoryId]}</p>
+                  <h3 className="font-editorial text-lg text-white">{service.title}</h3>
+                  {service.cardDescription && (
+                    <p className="font-body text-sm text-white/70 mt-1">{service.cardDescription}</p>
                   )}
                 </div>
               </Link>
@@ -106,29 +120,31 @@ export default async function ServicesPage() {
         </div>
       </section>
 
-      {/* Trust Block (003B) */}
+      {/* Trust Block */}
       <section className="py-16 md:py-20 bg-warm">
         <div className="max-w-3xl mx-auto px-5 text-center">
           <h2 className="font-display text-3xl md:text-4xl text-cream mb-8">
-            Why Choose Misha Creations
+            {hub?.trustHeading || 'Why Choose Misha Creations'}
           </h2>
           <ul className="space-y-3 text-left max-w-xl mx-auto">
-            <li className="flex items-start gap-3"><span className="text-gold mt-1 flex-shrink-0">&#10003;</span><span className="font-body text-mist">25+ years of museum-quality artistry in Houston</span></li>
-            <li className="flex items-start gap-3"><span className="text-gold mt-1 flex-shrink-0">&#10003;</span><span className="font-body text-mist">Every finish hand-applied by the artist personally</span></li>
-            <li className="flex items-start gap-3"><span className="text-gold mt-1 flex-shrink-0">&#10003;</span><span className="font-body text-mist">Complimentary in-home consultation</span></li>
-            <li className="flex items-start gap-3"><span className="text-gold mt-1 flex-shrink-0">&#10003;</span><span className="font-body text-mist">Serving River Oaks, Memorial, Tanglewood, West University, The Woodlands, and Bellaire</span></li>
+            {trustPoints.map((point, i) => (
+              <li key={i} className="flex items-start gap-3">
+                <span className="text-gold mt-1 flex-shrink-0">&#10003;</span>
+                <span className="font-body text-mist">{point}</span>
+              </li>
+            ))}
           </ul>
         </div>
       </section>
 
-      {/* Process Summary (003B) */}
+      {/* Process Summary */}
       <section className="py-16 md:py-20 bg-ink">
         <div className="max-w-3xl mx-auto px-5">
           <h2 className="font-display text-3xl md:text-4xl text-center text-cream mb-12">
-            How It Works
+            {hub?.processHeading || 'How It Works'}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {PROCESS_STEPS.map((step) => (
+            {processSteps.map((step) => (
               <div key={step.step} className="border border-muted/30 rounded-lg p-6">
                 <p className="font-body text-xs uppercase tracking-widest text-gold mb-2">Step {step.step}</p>
                 <h3 className="font-editorial text-lg text-cream mb-2">{step.name}</h3>
@@ -139,15 +155,15 @@ export default async function ServicesPage() {
         </div>
       </section>
 
-      {/* Hub FAQs (003B) */}
-      <FaqAccordion faqs={SERVICES_HUB_FAQS} heading="Decorative Painting FAQ" />
+      {/* Hub FAQs */}
+      <FaqAccordion faqs={hubFaqs} heading="Decorative Painting FAQ" />
 
-      {/* Area Links (003B) */}
+      {/* Area Links */}
       <section className="py-10 bg-warm">
         <div className="max-w-3xl mx-auto px-5 text-center">
           <p className="font-body text-xs uppercase tracking-widest text-muted mb-4">Serving Houston&apos;s Finest Neighborhoods</p>
           <div className="flex flex-wrap justify-center gap-3">
-            {COPY.socialProof.map((area) => (
+            {socialProof.map((area) => (
               <span key={area} className="font-body text-sm text-mist/70">{area}</span>
             ))}
           </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,22 @@
 import Link from 'next/link'
-import { NEIGHBORHOODS, FINISH_SURFACES, COPY } from '@/lib/constants'
+import { NEIGHBORHOODS, FINISH_SURFACES } from '@/lib/constants'
 
-export function Footer() {
+interface NavItem { slug: string; title?: string; name?: string }
+
+interface FooterProps {
+  services?: NavItem[]
+  areas?: NavItem[]
+}
+
+export function Footer({ services, areas }: FooterProps = {}) {
+  const serviceItems = services && services.length > 0
+    ? services.map((s) => ({ slug: s.slug, label: s.title || '' }))
+    : FINISH_SURFACES.map((f) => ({ slug: f.slug, label: f.title }))
+
+  const areaItems = areas && areas.length > 0
+    ? areas.map((a) => ({ slug: a.slug, label: a.name || '' }))
+    : NEIGHBORHOODS.map((n) => ({ slug: n.slug, label: n.name }))
+
   return (
     <footer className="bg-ink text-mist py-16 border-t border-warm">
       <div className="max-w-7xl mx-auto px-5">
@@ -16,13 +31,13 @@ export function Footer() {
           <div>
             <p className="font-editorial text-lg text-cream mb-3">Services</p>
             <div className="space-y-1">
-              {FINISH_SURFACES.map((f) => (
+              {serviceItems.map((f) => (
                 <Link
                   key={f.slug}
                   href={`/services/${f.slug}`}
                   className="block font-body text-sm hover:text-gold transition-colors"
                 >
-                  {f.title}
+                  {f.label}
                 </Link>
               ))}
             </div>
@@ -31,13 +46,13 @@ export function Footer() {
             <p className="font-editorial text-lg text-cream mb-3">Service Areas</p>
             <p className="font-body text-sm text-mist/70 mb-2">Serving the Greater Houston Metro Area</p>
             <div className="space-y-1">
-              {NEIGHBORHOODS.map((n) => (
+              {areaItems.map((n) => (
                 <Link
                   key={n.slug}
                   href={`/areas/${n.slug}`}
                   className="block font-body text-sm hover:text-gold transition-colors"
                 >
-                  {n.name}
+                  {n.label}
                 </Link>
               ))}
             </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,8 +4,24 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { FINISH_SURFACES, NEIGHBORHOODS } from '@/lib/constants'
 
-export function Header() {
+interface NavItem { slug: string; title?: string; name?: string }
+
+interface HeaderProps {
+  services?: NavItem[]
+  areas?: NavItem[]
+}
+
+export function Header({ services, areas }: HeaderProps = {}) {
   const [open, setOpen] = useState(false)
+
+  // Use CMS data if provided, fall back to constants
+  const serviceItems = services && services.length > 0
+    ? services.map((s) => ({ slug: s.slug, label: s.title || '' }))
+    : FINISH_SURFACES.map((f) => ({ slug: f.slug, label: f.title }))
+
+  const areaItems = areas && areas.length > 0
+    ? areas.map((a) => ({ slug: a.slug, label: a.name || '' }))
+    : NEIGHBORHOODS.map((n) => ({ slug: n.slug, label: n.name }))
 
   return (
     <header className="fixed top-0 inset-x-0 z-50 bg-ink/95 backdrop-blur-sm border-b border-warm">
@@ -28,13 +44,13 @@ export function Header() {
             </Link>
             <div className="absolute top-full left-0 pt-2 hidden group-hover:block">
               <div className="bg-warm border border-muted/20 rounded-lg shadow-lg py-2 min-w-[260px]">
-                {FINISH_SURFACES.map((f) => (
+                {serviceItems.map((f) => (
                   <Link
                     key={f.slug}
                     href={`/services/${f.slug}`}
                     className="block px-4 py-2 text-sm text-mist hover:bg-ink hover:text-gold transition-colors"
                   >
-                    {f.title}
+                    {f.label}
                   </Link>
                 ))}
               </div>
@@ -50,13 +66,13 @@ export function Header() {
             <div className="absolute top-full left-0 pt-2 hidden group-hover:block">
               <div className="bg-warm border border-muted/20 rounded-lg shadow-lg py-2 min-w-[260px]">
                 <p className="px-4 py-2 text-xs uppercase tracking-widest text-gold font-body">Serving the Greater Houston Metro Area</p>
-                {NEIGHBORHOODS.map((n) => (
+                {areaItems.map((n) => (
                   <Link
                     key={n.slug}
                     href={`/areas/${n.slug}`}
                     className="block px-4 py-2 text-sm text-mist hover:bg-ink hover:text-gold transition-colors"
                   >
-                    {n.name}
+                    {n.label}
                   </Link>
                 ))}
               </div>
@@ -108,14 +124,14 @@ export function Header() {
             Services
           </Link>
           <p className="text-xs uppercase tracking-widest text-muted font-body mt-4">Services</p>
-          {FINISH_SURFACES.map((f) => (
+          {serviceItems.map((f) => (
             <Link
               key={f.slug}
               href={`/services/${f.slug}`}
               className="block text-mist pl-3 font-body text-sm"
               onClick={() => setOpen(false)}
             >
-              {f.title}
+              {f.label}
             </Link>
           ))}
           <Link href="/recent-projects" className="block text-cream font-body mt-4" onClick={() => setOpen(false)}>
@@ -123,14 +139,14 @@ export function Header() {
           </Link>
           <p className="text-xs uppercase tracking-widest text-muted font-body mt-4">Areas</p>
           <p className="text-xs text-muted/60 font-body pl-3 mb-1">Serving the Greater Houston Metro Area</p>
-          {NEIGHBORHOODS.map((n) => (
+          {areaItems.map((n) => (
             <Link
               key={n.slug}
               href={`/areas/${n.slug}`}
               className="block text-mist pl-3 font-body text-sm"
               onClick={() => setOpen(false)}
             >
-              {n.name}
+              {n.label}
             </Link>
           ))}
           <Link href="/faq" className="block mt-4 text-cream font-body" onClick={() => setOpen(false)}>


### PR DESCRIPTION
## Summary
- Services hub page reads intro, trust, FAQs, process steps from Sanity
- Process page reads steps, FAQs, about section from Sanity
- Header/Footer accept nav data as props from layout.tsx
- layout.tsx fetches navigation data from Sanity via getNavData()
- All components fall back to constants.ts if Sanity fetch fails
- Zero visual changes — content is identical

## Test plan
- [ ] Services hub page renders correctly with all sections
- [ ] Process page renders correctly with all sections
- [ ] Header dropdowns show all services and areas
- [ ] Footer shows all services and areas
- [ ] Mobile menu works correctly
- [ ] Edit servicesHubPage in Sanity and verify update within 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)