### PR TITLE
Add project gallery system with image count links

### DIFF
--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { getPieceBySlug, getAllPortfolioSlugs, getRelatedPieces } from '@/lib/queries'
+import { getPieceBySlug, getAllPortfolioSlugs, getRelatedPieces, getProjectForPiece } from '@/lib/queries'
 import { sanityImageUrl } from '@/lib/sanity'
 import { FINISH_SURFACES } from '@/lib/constants'
 import { PortfolioDetailClient } from '@/components/PortfolioDetailClient'
@@ -39,7 +39,10 @@ export default async function PieceDetailPage({ params }: PageProps) {
   const piece = await getPieceBySlug(slug)
   if (!piece) return notFound()
 
-  const relatedPieces = await getRelatedPieces(piece.category, piece._id, 3)
+  const [relatedPieces, projectInfo] = await Promise.all([
+    getRelatedPieces(piece.category, piece._id, 3),
+    getProjectForPiece(piece._id).catch(() => null),
+  ])
   const finish = FINISH_SURFACES.find((f) => f.categoryId === piece.category)
 
   // Build all images array: hero + additional images
@@ -132,6 +135,20 @@ export default async function PieceDetailPage({ params }: PageProps) {
                     </span>
                   ))}
                 </div>
+              )}
+              {projectInfo && (
+                <Link
+                  href={`/projects/${projectInfo.slug}`}
+                  className="inline-flex items-center gap-2 mt-6 px-5 py-2.5 bg-warm rounded-lg border border-muted/20 hover:border-gold/40 transition-colors group"
+                >
+                  <span className="font-editorial text-sm text-cream group-hover:text-gold transition-colors">
+                    See Full Project
+                  </span>
+                  <span className="font-body text-xs text-muted bg-ink/50 px-2 py-0.5 rounded-full">
+                    {projectInfo.pieceCount} {projectInfo.pieceCount === 1 ? 'image' : 'images'}
+                  </span>
+                  <span className="text-gold text-xs">&rarr;</span>
+                </Link>
               )}
             </div>
 

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { getProjectBySlug, getAllProjectSlugs } from '@/lib/queries'
+import { PortfolioCard } from '@/components/PortfolioCard'
+import { CtaSection } from '@/components/CtaSection'
+import { JsonLd } from '@/components/JsonLd'
+import { notFound } from 'next/navigation'
+
+export const revalidate = 60
+
+export async function generateStaticParams() {
+  const slugs = await getAllProjectSlugs().catch(() => [])
+  return slugs.map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
+  const project = await getProjectBySlug(slug).catch(() => null)
+  if (!project) return { title: 'Project | Misha Creations' }
+
+  const title = `${project.title} | Project Gallery | Misha Creations Houston`
+  const description = project.description
+    || `Explore the ${project.title} project by Misha Creations — ${project.pieceCount} hand-painted images from this custom decorative painting project in Houston.`
+
+  return {
+    title,
+    description: description.slice(0, 160),
+    alternates: { canonical: `https://mishacreations.com/projects/${slug}` },
+    openGraph: { title, description: description.slice(0, 160), url: `https://mishacreations.com/projects/${slug}` },
+  }
+}
+
+export default async function ProjectPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const project = await getProjectBySlug(slug)
+
+  if (!project) notFound()
+
+  const pieces = project.pieces || []
+
+  const projectSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'ImageGallery',
+    name: project.title,
+    description: project.description || `A ${project.pieceCount}-image project by Misha Creations`,
+    numberOfItems: project.pieceCount,
+    author: {
+      '@type': 'LocalBusiness',
+      name: 'Misha Creations',
+      url: 'https://mishacreations.com',
+    },
+  }
+
+  return (
+    <>
+      <JsonLd data={projectSchema} />
+
+      {/* Hero */}
+      <section className="bg-ink pt-32 pb-16 md:pt-40 md:pb-20">
+        <div className="max-w-4xl mx-auto px-5 text-center">
+          <p className="font-body text-xs uppercase tracking-[0.2em] text-gold mb-4">
+            Project Gallery
+          </p>
+          <h1 className="font-display text-[36px] md:text-[52px] text-cream mb-4 leading-tight">
+            {project.title}
+          </h1>
+          {project.description && (
+            <p className="font-editorial text-lg md:text-xl text-mist max-w-2xl mx-auto mb-4">
+              {project.description}
+            </p>
+          )}
+          <p className="font-body text-sm text-muted">
+            {project.pieceCount} {project.pieceCount === 1 ? 'image' : 'images'} in this project
+          </p>
+          <div className="w-8 h-px bg-gold mx-auto mt-6" />
+        </div>
+      </section>
+
+      {/* Image Grid */}
+      <section className="bg-ink py-12 md:py-16">
+        <div className="max-w-7xl mx-auto px-5">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {pieces.map((piece) => (
+              <PortfolioCard key={piece._id} piece={piece} sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw" />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Back nav */}
+      <section className="bg-warm py-8">
+        <div className="max-w-7xl mx-auto px-5 flex flex-wrap gap-4 justify-center">
+          <Link
+            href="/recent-projects"
+            className="font-body text-sm text-mist hover:text-gold transition-colors"
+          >
+            &larr; All Projects
+          </Link>
+          <Link
+            href="/portfolio"
+            className="font-body text-sm text-mist hover:text-gold transition-colors"
+          >
+            View Full Portfolio
+          </Link>
+        </div>
+      </section>
+
+      <CtaSection />
+    </>
+  )
+}

--- a/src/app/recent-projects/page.tsx
+++ b/src/app/recent-projects/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next'
-import { getMishaSelectPieces } from '@/lib/queries'
+import Link from 'next/link'
+import { getMishaSelectPieces, getAllProjects } from '@/lib/queries'
 import { COPY } from '@/lib/constants'
 import { PortfolioCard } from '@/components/PortfolioCard'
+import { SanityImage } from '@/components/SanityImage'
 import { CtaSection } from '@/components/CtaSection'
 
 export const revalidate = 60
@@ -22,7 +24,10 @@ export const metadata: Metadata = {
 }
 
 export default async function RecentProjectsPage() {
-  const pieces = await getMishaSelectPieces(12)
+  const [pieces, projects] = await Promise.all([
+    getMishaSelectPieces(12),
+    getAllProjects().catch(() => []),
+  ])
 
   return (
     <>
@@ -40,9 +45,76 @@ export default async function RecentProjectsPage() {
         </div>
       </section>
 
+      {/* Project Galleries */}
+      {projects.length > 0 && (
+        <section className="py-12 md:py-16 bg-ink border-b border-warm">
+          <div className="max-w-7xl mx-auto px-5">
+            <h2 className="font-editorial text-2xl text-cream mb-8 text-center">
+              Project Galleries
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {projects.map((project) => (
+                <Link
+                  key={project._id}
+                  href={`/projects/${project.slug.current}`}
+                  className="group relative block overflow-hidden rounded-lg bg-warm"
+                >
+                  <div className="relative aspect-[4/3] overflow-hidden">
+                    {project.heroImage?.asset ? (
+                      <SanityImage
+                        image={project.heroImage}
+                        alt={project.title}
+                        fill
+                        className="object-cover transition-transform duration-500 group-hover:scale-105"
+                        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                      />
+                    ) : project.pieces?.[0]?.heroImage?.asset ? (
+                      <SanityImage
+                        image={project.pieces[0].heroImage}
+                        alt={project.title}
+                        fill
+                        className="object-cover transition-transform duration-500 group-hover:scale-105"
+                        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                      />
+                    ) : (
+                      <div className="w-full h-full bg-ink/50 flex items-center justify-center">
+                        <span className="text-muted text-sm">No preview</span>
+                      </div>
+                    )}
+                    {/* Image count badge */}
+                    <div className="absolute top-3 right-3 bg-ink/80 backdrop-blur-sm text-cream text-xs font-body px-2.5 py-1 rounded-full">
+                      {project.pieceCount} {project.pieceCount === 1 ? 'image' : 'images'}
+                    </div>
+                  </div>
+                  <div className="p-4">
+                    <h3 className="font-editorial text-lg text-cream group-hover:text-gold transition-colors line-clamp-2">
+                      {project.title}
+                    </h3>
+                    {project.description && (
+                      <p className="font-body text-sm text-mist mt-1 line-clamp-2">
+                        {project.description}
+                      </p>
+                    )}
+                    <span className="font-body text-xs text-gold mt-2 inline-block">
+                      View Project &rarr;
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Individual Pieces */}
       {pieces.length > 0 && (
         <section className="py-16 md:py-24 bg-warm">
           <div className="max-w-7xl mx-auto px-5">
+            {projects.length > 0 && (
+              <h2 className="font-editorial text-2xl text-cream mb-8 text-center">
+                Featured Works
+              </h2>
+            )}
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
               {pieces.map((piece, i) => (
                 <PortfolioCard

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -369,3 +369,57 @@ export async function getNavData(): Promise<{
   ])
   return { services, areas }
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Project Galleries
+   ═══════════════════════════════════════════════════════════════ */
+
+export interface StudioProject {
+  _id: string
+  title: string
+  slug: { current: string }
+  category: string
+  description?: string
+  heroImage?: SanityImage
+  displayOrder?: number
+  pieces: PortfolioPiece[]
+  pieceCount: number
+}
+
+const PROJECT_FIELDS = `
+  _id, title, slug, category, description, displayOrder,
+  heroImage { asset, hotspot, alt, "lqip": asset->metadata.lqip },
+  "pieces": pieces[]->{ ${PIECE_FIELDS} },
+  "pieceCount": count(pieces)
+`
+
+/** All published projects for /recent-projects listing */
+export async function getAllProjects(): Promise<StudioProject[]> {
+  return sanityClient.fetch(`
+    *[_type == "studioProject" && defined(slug.current) && count(pieces) > 0]
+    | order(displayOrder asc) { ${PROJECT_FIELDS} }
+  `)
+}
+
+/** Single project by slug */
+export async function getProjectBySlug(slug: string): Promise<StudioProject | null> {
+  return sanityClient.fetch(`
+    *[_type == "studioProject" && slug.current == $slug][0] { ${PROJECT_FIELDS} }
+  `, { slug })
+}
+
+/** All project slugs for generateStaticParams */
+export async function getAllProjectSlugs(): Promise<string[]> {
+  return sanityClient.fetch(`
+    *[_type == "studioProject" && defined(slug.current) && count(pieces) > 0].slug.current
+  `)
+}
+
+/** Get project info for a piece (if it belongs to a project) */
+export async function getProjectForPiece(pieceId: string): Promise<{ title: string; slug: string; pieceCount: number } | null> {
+  return sanityClient.fetch(`
+    *[_type == "studioProject" && $pieceId in pieces[]._ref][0]{
+      title, "slug": slug.current, "pieceCount": count(pieces)
+    }
+  `, { pieceId })
+}


### PR DESCRIPTION
## Summary
New /projects/[slug] route for project gallery pages. Updated /recent-projects to show project cards with image counts. Every portfolio detail page now shows a "See Full Project (X images)" link if the piece belongs to a project.

## CLAUDE.md Rule Added
Any image associated with a project must display a link to its project gallery with image count on the detail page.

## Test plan
- [ ] /projects/{slug} — renders project with all images
- [ ] /recent-projects — shows Project Galleries section
- [ ] /portfolio/{slug} — shows project link when piece has a project

🤖 Generated with [Claude Code](https://claude.com/claude-code)