### PR TITLE
Filter unpublished/archived from project queries

### DIFF
--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -389,8 +389,8 @@ export interface StudioProject {
 const PROJECT_FIELDS = `
   _id, title, slug, category, description, displayOrder,
   heroImage { asset, hotspot, alt, "lqip": asset->metadata.lqip },
-  "pieces": pieces[]->{ ${PIECE_FIELDS} },
-  "pieceCount": count(pieces)
+  "pieces": pieces[]->[published == true && coalesce(archived, false) != true]{ ${PIECE_FIELDS} },
+  "pieceCount": count(pieces[]->[published == true && coalesce(archived, false) != true])
 `
 
 /** All published projects for /recent-projects listing */


### PR DESCRIPTION
Prevents 404s on project gallery pages by filtering pieces in GROQ query.