### PR TITLE
feat: manual closeout evidence gate and service watchdog

### DIFF
--- a/.github/workflows/cr-manual-closeout.yml
+++ b/.github/workflows/cr-manual-closeout.yml
@@ -1,0 +1,226 @@
+name: CR Manual Closeout
+
+on:
+  issues:
+    types: [closed, labeled]
+
+jobs:
+  manual-closeout:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Enforce evidence gate and record governed closeout for manual-route CRs
+        uses: actions/github-script@v7
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const issueNumber = issue.number;
+            const eventAction = context.payload.action;
+            const labelNames = issue.labels.map(l => l.name);
+
+            // Only process manual-route CRs — issues with developer-required or in-progress label.
+            // Issues that already have cr-completed are intentionally excluded.
+            const isManualRoute = labelNames.includes('cr-developer-required') ||
+                                  labelNames.includes('cr-in-progress');
+
+            const sbUrl = process.env.SUPABASE_URL;
+            const sbKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+            const sbHeaders = sbUrl && sbKey ? {
+              'apikey': sbKey,
+              'Authorization': `Bearer ${sbKey}`,
+              'Content-Type': 'application/json',
+              'Prefer': 'return=minimal'
+            } : null;
+
+            // ── Helper: PATCH Supabase cr_tasks by cr_number ──
+            async function patchSupabase(crNum, fields) {
+              if (!sbHeaders) return;
+              try {
+                const res = await fetch(
+                  `${sbUrl}/rest/v1/cr_tasks?cr_number=eq.${crNum}&tenant=eq.misha-main`,
+                  { method: 'PATCH', headers: sbHeaders, body: JSON.stringify(fields) }
+                );
+                if (!res.ok) {
+                  const text = await res.text();
+                  core.warning(`CR-${crNum}: Supabase PATCH failed (${res.status}): ${text}`);
+                }
+              } catch (e) {
+                core.warning(`CR-${crNum}: Supabase PATCH error: ${e.message}`);
+              }
+            }
+
+            // ══════════════════════════════════════════════════════════
+            // WORK-STARTED SIGNAL
+            // Fires when cr-in-progress label is added to a manual-route issue.
+            // Records in-progress state in Supabase and posts start acknowledgment.
+            // ══════════════════════════════════════════════════════════
+
+            if (eventAction === 'labeled') {
+              const addedLabel = context.payload.label.name;
+              if (addedLabel !== 'cr-in-progress') return;
+              if (!isManualRoute) {
+                core.info(`CR-${issueNumber}: cr-in-progress added but not a manual-route CR — skipping`);
+                return;
+              }
+
+              core.info(`CR-${issueNumber}: cr-in-progress label added — recording work-started`);
+
+              await patchSupabase(issueNumber, { status: 'in-progress' });
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: [
+                  `## 🔧 CR-${issueNumber} — Work started`,
+                  '',
+                  'This CR has been marked in-progress.',
+                  '',
+                  '**When work is complete**, post a closing comment that describes:',
+                  '- What was done',
+                  '- Where the change can be seen (URL, page, or location)',
+                  '- Any caveats or follow-on items',
+                  '',
+                  'Then close this issue. A governed closeout record will be created automatically.',
+                ].join('\n')
+              });
+              return;
+            }
+
+            // ══════════════════════════════════════════════════════════
+            // EVIDENCE GATE
+            // Fires when a manual-route issue is closed.
+            // Requires a human completion comment. No evidence → reopen.
+            // Evidence found → governed closeout: Supabase done, cr-completed label, ack.
+            // ══════════════════════════════════════════════════════════
+
+            if (eventAction !== 'closed') return;
+
+            if (!isManualRoute) {
+              core.info(`CR-${issueNumber}: closed but not a manual-route CR — skipping`);
+              return;
+            }
+
+            core.info(`CR-${issueNumber}: manual-route CR closed — checking for evidence`);
+
+            // Fetch recent comments
+            const commentsRes = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 20
+            });
+
+            // Evidence = any comment from a human (not a bot) with substantive text (>30 chars).
+            const humanComments = commentsRes.data.filter(c =>
+              !c.user.login.endsWith('[bot]') &&
+              c.body.trim().length > 30
+            );
+
+            if (humanComments.length === 0) {
+              // ── No evidence — reopen and post governance hold ──
+              core.warning(`CR-${issueNumber}: Closed without evidence — reopening`);
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: 'open'
+              });
+
+              // Swap to cr-closeout-ungoverned
+              for (const label of ['cr-developer-required', 'cr-in-progress']) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    issue_number: issueNumber, name: label
+                  });
+                } catch (e) { /* may not be present */ }
+              }
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: issueNumber, labels: ['cr-closeout-ungoverned']
+                });
+              } catch (e) { /* label may not exist in repo yet */ }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: [
+                  `## 🔒 Governance Hold — CR-${issueNumber} closed without evidence`,
+                  '',
+                  'This CR was closed without a completion summary.',
+                  'It has been **reopened** to prevent ungoverned closeout.',
+                  '',
+                  '**To close this CR correctly:**',
+                  '1. Post a comment describing what was done (what changed, where it can be seen)',
+                  '2. Close the issue again',
+                  '',
+                  'The service will then record the evidence and acknowledge the closure.',
+                  '',
+                  '_Evidence is required. "Evidence or it did not happen."_',
+                ].join('\n')
+              });
+              return;
+            }
+
+            // ── Evidence found — proceed with governed closeout ──
+            const evidenceComment = humanComments[humanComments.length - 1];
+            const evidenceExcerpt = evidenceComment.body.trim().slice(0, 400);
+
+            core.info(`CR-${issueNumber}: Evidence from @${evidenceComment.user.login} — governed closeout`);
+
+            // Sync Supabase to done
+            await patchSupabase(issueNumber, {
+              status: 'done',
+              completed_at: new Date().toISOString(),
+              result: {
+                closeout_method: 'manual',
+                evidence_author: evidenceComment.user.login,
+                evidence_comment_id: evidenceComment.id,
+                evidence_excerpt: evidenceExcerpt,
+                closeout_at: new Date().toISOString()
+              }
+            });
+
+            // Swap labels: remove developer-required/in-progress, apply cr-completed
+            for (const label of ['cr-developer-required', 'cr-in-progress', 'cr-closeout-ungoverned']) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: issueNumber, name: label
+                });
+              } catch (e) { /* may not be present */ }
+            }
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber, labels: ['cr-completed']
+              });
+            } catch (e) { /* label may not exist in repo yet */ }
+
+            // Post governed completion acknowledgment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: [
+                `## ✅ CR-${issueNumber} — Governed closeout recorded`,
+                '',
+                `**Completed by:** @${evidenceComment.user.login}`,
+                `**Closed at:** ${new Date().toISOString()}`,
+                '',
+                '**Evidence on record:**',
+                `> ${evidenceExcerpt.replace(/\n/g, '\n> ')}`,
+                '',
+                'Supabase state synchronized to `done`. This CR is now closed.',
+              ].join('\n')
+            });
+
+            core.info(`CR-${issueNumber}: Governed closeout complete`);

--- a/.github/workflows/cr-watchdog.yml
+++ b/.github/workflows/cr-watchdog.yml
@@ -1,0 +1,289 @@
+name: CR Service Watchdog
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-stale-crs:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Monitor stale manual-path, escalated, and validation-failed CRs
+        uses: actions/github-script@v7
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        with:
+          script: |
+            const sbUrl = process.env.SUPABASE_URL;
+            const sbKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+            const headers = {
+              'apikey': sbKey,
+              'Authorization': `Bearer ${sbKey}`,
+              'Content-Type': 'application/json'
+            };
+
+            const now = new Date();
+
+            // ── Helper: hours since a date ──
+            function hoursSince(dateStr) {
+              if (!dateStr) return Infinity;
+              return (now - new Date(dateStr)) / (1000 * 60 * 60);
+            }
+
+            // ── Helper: check if watchdog already posted recently ──
+            async function hasRecentWatchdogComment(issueNumber, withinHours = 24) {
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 10
+              });
+              return comments.data.some(c =>
+                c.user.login === 'github-actions[bot]' &&
+                c.body.includes('Service Watchdog') &&
+                hoursSince(c.created_at) < withinHours
+              );
+            }
+
+            // ══════════════════════════════════════════
+            // CHECK 1: Manual-path CRs stale > 24 hours
+            // ══════════════════════════════════════════
+
+            const manualLabels = ['cr-developer-required'];
+
+            for (const label of manualLabels) {
+              const issues = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: label,
+                state: 'open',
+                per_page: 20
+              });
+
+              for (const issue of issues.data) {
+                const ageHours = hoursSince(issue.created_at);
+
+                const hasRecent = await hasRecentWatchdogComment(issue.number);
+                if (hasRecent) continue;
+
+                if (ageHours > 48) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: [
+                      `## 🔔 Service Watchdog — CR-${issue.number} needs attention`,
+                      '',
+                      `This CR has been open for **${Math.round(ageHours)} hours** without resolution.`,
+                      `**Route:** ${label}`,
+                      `**Priority:** ${issue.labels.map(l => l.name).find(n => ['urgent', 'before-launch', 'nice-to-have'].includes(n)) || 'unset'}`,
+                      '',
+                      '**Required action:** A developer or team member must either:',
+                      '1. Begin work and add the `cr-in-progress` label',
+                      '2. Re-classify this CR if the routing was incorrect',
+                      '3. Close with explanation if the request is not actionable',
+                      '',
+                      '_This is an automated service-level reminder. CRs should not remain in manual queue without visible progress beyond 24 hours._'
+                    ].join('\n')
+                  });
+                  core.warning(`CR-${issue.number}: Manual-path stale for ${Math.round(ageHours)}h — watchdog posted`);
+
+                } else if (ageHours > 24) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: [
+                      `## ⏰ Service Watchdog — CR-${issue.number} approaching SLA threshold`,
+                      '',
+                      `This CR has been in the manual queue for **${Math.round(ageHours)} hours**.`,
+                      `**Route:** ${label}`,
+                      '',
+                      'A team member should review this request and post a status update within the next 24 hours.',
+                      '',
+                      '_Automated SLA reminder._'
+                    ].join('\n')
+                  });
+                  core.info(`CR-${issue.number}: Manual-path nearing SLA — watchdog posted`);
+                }
+              }
+            }
+
+            // ══════════════════════════════════════════════════════════
+            // CHECK 2: In-progress manual CRs stale > 48 hours
+            // ══════════════════════════════════════════════════════════
+
+            const inProgressIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'cr-in-progress',
+              state: 'open',
+              per_page: 20
+            });
+
+            for (const issue of inProgressIssues.data) {
+              const ageHours = hoursSince(issue.created_at);
+              const hasRecent = await hasRecentWatchdogComment(issue.number);
+              if (hasRecent) continue;
+
+              if (ageHours > 96) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: [
+                    `## 🔔 Service Watchdog — CR-${issue.number} in-progress beyond 96 hours`,
+                    '',
+                    `This CR has been marked in-progress for **${Math.round(ageHours)} hours** without closure.`,
+                    '',
+                    '**Required action:**',
+                    '1. Post a status update on what has been done so far',
+                    '2. Complete the work and close with a completion summary',
+                    '3. Or re-classify if scope has changed',
+                    '',
+                    '_Automated in-progress SLA reminder._'
+                  ].join('\n')
+                });
+                core.warning(`CR-${issue.number}: In-progress for ${Math.round(ageHours)}h — critical watchdog posted`);
+
+              } else if (ageHours > 48) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: [
+                    `## ⏰ Service Watchdog — CR-${issue.number} in-progress status update needed`,
+                    '',
+                    `This CR has been marked in-progress for **${Math.round(ageHours)} hours**.`,
+                    '',
+                    'Please post a status update or complete the work and close with a summary.',
+                    '',
+                    '_Automated in-progress SLA reminder._'
+                  ].join('\n')
+                });
+                core.info(`CR-${issue.number}: In-progress for ${Math.round(ageHours)}h — watchdog posted`);
+              }
+            }
+
+            // ══════════════════════════════════════════
+            // CHECK 3: Validation-failed CRs stale > 2 hours
+            // ══════════════════════════════════════════
+
+            const valFailedIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'cr-validation-failed',
+              state: 'open',
+              per_page: 20
+            });
+
+            for (const issue of valFailedIssues.data) {
+              const ageHours = hoursSince(issue.created_at);
+              const hasRecent = await hasRecentWatchdogComment(issue.number, 6);
+              if (hasRecent) continue;
+
+              if (ageHours > 2) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: [
+                    `## ⚠️ Service Watchdog — CR-${issue.number} validation failed and unresolved`,
+                    '',
+                    `This CR was pushed but production validation failed **${Math.round(ageHours)} hours ago**.`,
+                    'The change may be live but has not been confirmed.',
+                    '',
+                    '**Required action:**',
+                    '1. Check the live page manually',
+                    '2. If the change is correct: reply "Approved" to close',
+                    '3. If the change is wrong: reply with details for correction',
+                    '',
+                    '_Automated validation-recovery reminder._'
+                  ].join('\n')
+                });
+                core.warning(`CR-${issue.number}: Validation-failed for ${Math.round(ageHours)}h — watchdog posted`);
+              }
+            }
+
+            // ══════════════════════════════════════════
+            // CHECK 4: Escalated CRs stale > 4 hours
+            // ══════════════════════════════════════════
+
+            const escalatedIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'cr-escalated',
+              state: 'open',
+              per_page: 20
+            });
+
+            for (const issue of escalatedIssues.data) {
+              const ageHours = hoursSince(issue.created_at);
+              const hasRecent = await hasRecentWatchdogComment(issue.number, 12);
+              if (hasRecent) continue;
+
+              if (ageHours > 4) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: [
+                    `## 🔒 Service Watchdog — CR-${issue.number} escalation unresolved`,
+                    '',
+                    `This CR was escalated **${Math.round(ageHours)} hours ago** and has not been resolved.`,
+                    '',
+                    '**Required action:** The escalation owner must investigate and either:',
+                    '1. Fix the issue and update status',
+                    '2. Re-route to the correct handling path',
+                    '3. Close with explanation',
+                    '',
+                    '_Automated escalation follow-up reminder._'
+                  ].join('\n')
+                });
+                core.warning(`CR-${issue.number}: Escalated for ${Math.round(ageHours)}h — watchdog posted`);
+              }
+            }
+
+            // ══════════════════════════════════════════
+            // CHECK 5: Auto-execute CRs pending > 30 min
+            // ══════════════════════════════════════════
+
+            if (sbUrl && sbKey) {
+              const pendingRes = await fetch(
+                `${sbUrl}/rest/v1/cr_tasks?status=eq.pending&auto_execute=eq.true&tenant=eq.misha-main&select=cr_number,queued_at`,
+                { headers }
+              );
+              if (pendingRes.ok) {
+                const pendingTasks = await pendingRes.json();
+                for (const task of pendingTasks) {
+                  const pendingMinutes = (now - new Date(task.queued_at)) / (1000 * 60);
+                  if (pendingMinutes > 30) {
+                    const hasRecent = await hasRecentWatchdogComment(task.cr_number, 1);
+                    if (!hasRecent) {
+                      await github.rest.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: task.cr_number,
+                        body: [
+                          `## ⏳ Service Watchdog — CR-${task.cr_number} pending beyond SLA`,
+                          '',
+                          `This auto-execute CR has been pending for **${Math.round(pendingMinutes)} minutes** without executor pickup.`,
+                          '',
+                          'This may indicate executor workflow failure or queue visibility issue.',
+                          '',
+                          '_Automated pending-state SLA alert._'
+                        ].join('\n')
+                      });
+                      core.warning(`CR-${task.cr_number}: Pending for ${Math.round(pendingMinutes)}min — exceeds 30min SLA`);
+                    }
+                  }
+                }
+              }
+            }
+
+            core.info('Watchdog check complete');


### PR DESCRIPTION
## Summary
Adds the final two mandatory baseline controls identified in the cross-repo governance review:

- **Manual closeout evidence gate** (`cr-manual-closeout.yml`) — developer-required CRs cannot close without a human completion comment. No evidence → issue reopened + governance hold. Evidence found → governed closeout with Supabase sync and evidence on record.
- **Service watchdog** (`cr-watchdog.yml`) — 5 checks every 6 hours covering all CR states. Prevents silent stalling with SLA-aware nudges and per-check deduplication.

## Why
PR #49 correctly routes non-content-update CRs to `cr-developer-required`. PR #52 added deployment truth gates. But manual-route CRs still had no lifecycle governance — they could stall indefinitely or close with no record of what was done. Supabase would stay at `pending` forever for manually-resolved CRs.

## New workflows

### cr-manual-closeout.yml
| Event | Behavior |
|-------|----------|
| `cr-in-progress` label added | Supabase → in-progress, work-started comment |
| Issue closed, no evidence | Reopen + governance hold (`cr-closeout-ungoverned`) |
| Issue closed, evidence present | Governed closeout: Supabase → done, `cr-completed` label, evidence excerpt |

### cr-watchdog.yml
| Check | Label/Source | Threshold | Dedup |
|-------|-------------|-----------|-------|
| Manual-path stale | cr-developer-required | 24h warn, 48h critical | 24h |
| In-progress stale | cr-in-progress | 48h warn, 96h critical | 24h |
| Validation-failed | cr-validation-failed | 2h | 6h |
| Escalated | cr-escalated | 4h | 12h |
| Auto-execute pending | Supabase query | 30min | 1h |

## No regressions
- No existing workflows modified
- Auto lane (content-update → executor → notifier → approval) fully preserved
- Two new files only

## Test plan
- [ ] Close `cr-developer-required` issue with no comment → reopen + governance hold
- [ ] Post evidence comment + close → governed closeout + cr-completed
- [ ] Add `cr-in-progress` label → work-started comment + Supabase in-progress
- [ ] Trigger watchdog → appropriate comments on stale issues
- [ ] Watchdog dedup → no duplicate comments within window
- [ ] Content-update CR → auto lane still works end-to-end

## Evidence
TTP packet: `TTP-CR-SERVICE-STABILIZATION-MISHA-003-MANUAL-CLOSEOUT-AND-WATCHDOG`

🤖 Generated with [Claude Code](https://claude.com/claude-code)