### PR TITLE
fix(cr-manual-closeout): recognize cr-closeout-ungoverned on re-close

### DIFF
--- a/.github/workflows/cr-manual-closeout.yml
+++ b/.github/workflows/cr-manual-closeout.yml
@@ -25,7 +25,8 @@ jobs:
             // Only process manual-route CRs — issues with developer-required or in-progress label.
             // Issues that already have cr-completed are intentionally excluded.
             const isManualRoute = labelNames.includes('cr-developer-required') ||
-                                  labelNames.includes('cr-in-progress');
+                                  labelNames.includes('cr-in-progress') ||
+                                  labelNames.includes('cr-closeout-ungoverned');
 
             const sbUrl = process.env.SUPABASE_URL;
             const sbKey = process.env.SUPABASE_SERVICE_ROLE_KEY;


### PR DESCRIPTION
## Summary
Fixes blocker F-001: issues reopened under governance hold (`cr-closeout-ungoverned`) were not recognized as manual-route issues on re-close, so governed closeout actions were skipped.

## What changed
One line added to `isManualRoute` predicate in `cr-manual-closeout.yml`:
```javascript
const isManualRoute = labelNames.includes('cr-developer-required') ||
                      labelNames.includes('cr-in-progress') ||
                      labelNames.includes('cr-closeout-ungoverned'); // ← added
```

## Why
When the evidence gate reopens an issue (removing `cr-developer-required`, adding `cr-closeout-ungoverned`), the subsequent re-close with evidence must still trigger the governed closeout path — Supabase sync, acknowledgment comment, and `cr-completed` label.

## Validation
After merge, re-close validation:
1. Close a manual-route issue without evidence → expect reopen + governance hold
2. Post evidence comment (>30 chars) → close again
3. Verify: governed closeout acknowledgment posts, `cr-completed` label applied

## Blocker reference
F-001 from TTP-CR-SERVICE-CERTIFICATION-MISHA-002