### PR TITLE
copy(about): revise process step 02 Design description

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -720,7 +720,7 @@ export const PROCESS_STEPS = [
   {
     step: '02',
     name: 'Design',
-    desc: 'Misha creates physical finish samples and detailed design sketches customized to your tastes for your approval before any brushwork begins.',
+    desc: 'Misha develops the necessary visuals and examples of her proposed approach which she will review and customize to your tastes for your approval before any brushwork or finishwork begins.',
   },
   {
     step: '03',


### PR DESCRIPTION
## Summary

One-line copy change to step 02 ("Design") of the How We Work Together / Our Process section on the About page.

**Before:**
> Misha creates physical finish samples and detailed design sketches customized to your tastes for your approval before any brushwork begins.

**After:**
> Misha develops the necessary visuals and examples of her proposed approach which she will review and customize to your tastes for your approval before any brushwork or finishwork begins.

## Where this text appears

- `/about` page → uses `PROCESS_STEPS` from `src/lib/constants.ts` (updated in this PR)
- `/process` page → uses Sanity `processPage.processSteps` (already updated via Sanity client)
- `/services`, service hub → uses Sanity `siteGlobals.processSteps` (already updated via Sanity client)

All three sources now show the same step 02 text.

## Test plan
- [x] `npx next build` — passes
- [ ] Preview deploy review
- [ ] Production `/about` verified after merge: step 02 shows new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)