### PR TITLE
copy(about): broaden hero subtitle to include business / guests / customers

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -44,7 +44,7 @@ export default function AboutPage() {
             The Story Behind the Finish
           </h1>
           <p className="font-body text-lg text-mist leading-relaxed">
-            Every surface tells a story. Ours began over 25 years ago with a simple belief: your home should move you.
+            Every surface tells a story. Ours began over 25 years ago with a simple belief: Your home or business should move you, your guests and customers.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary

One-line copy change to the About page hero subtitle (under "The Story Behind the Finish").

**Before:**
> Every surface tells a story. Ours began over 25 years ago with a simple belief: your home should move you.

**After:**
> Every surface tells a story. Ours began over 25 years ago with a simple belief: Your home or business should move you, your guests and customers.

## Why
Reflects that Misha's work serves commercial clients (Houston Zoo, Rainforest Café, Katy Mills, restaurants, law firms, Petro-China) in addition to residential — and that the finish is for the people who experience the space, not just the owner.

## Test plan
- [x] `npx next build` — passes
- [ ] Preview deploy review
- [ ] Production `/about` verified after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)