### PR TITLE
copy(site): broaden audience language — homes, businesses, and public spaces

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,13 +5,13 @@ import { PROCESS_STEPS } from '@/lib/constants'
 
 export const metadata: Metadata = {
   title: 'About Misha Thibeaux | 25+ Years of Decorative Artistry in Houston | Misha Creations',
-  description: "Meet Misha Thibeaux — muralist, luminist, and decorative artist with 25+ years transforming Houston's finest homes. Formal training at Buon Fresco School of Venetian Plastering, Nicola Vigini Studios, Faux Effects, Definitive School of Decorative Arts, Nina's Decorative Finishes, and iVenetian with Eli Lucero.",
+  description: "Meet Misha Thibeaux — muralist, luminist, and decorative artist with 25+ years transforming Houston's finest homes, businesses, and public spaces. Formal training at Buon Fresco School of Venetian Plastering, Nicola Vigini Studios, Faux Effects, Definitive School of Decorative Arts, Nina's Decorative Finishes, and iVenetian with Eli Lucero.",
   alternates: {
     canonical: 'https://mishacreations.com/about',
   },
   openGraph: {
     title: 'About Misha Thibeaux | 25+ Years of Decorative Artistry in Houston | Misha Creations',
-    description: "Meet Misha Thibeaux — muralist, luminist, and decorative artist with 25+ years transforming Houston's finest homes. Formal training at Buon Fresco School of Venetian Plastering, Nicola Vigini Studios, Faux Effects, Definitive School of Decorative Arts, Nina's Decorative Finishes, and iVenetian with Eli Lucero.",
+    description: "Meet Misha Thibeaux — muralist, luminist, and decorative artist with 25+ years transforming Houston's finest homes, businesses, and public spaces. Formal training at Buon Fresco School of Venetian Plastering, Nicola Vigini Studios, Faux Effects, Definitive School of Decorative Arts, Nina's Decorative Finishes, and iVenetian with Eli Lucero.",
     url: 'https://mishacreations.com/about',
     type: 'profile',
   },

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -52,7 +52,7 @@ export default async function GalleryPage() {
             Gallery
           </h1>
           <p className="font-editorial text-xl md:text-2xl text-mist max-w-2xl mx-auto mb-6">
-            A curated collection of decorative finishes across Houston&apos;s finest homes
+            A curated collection of decorative finishes across Houston&apos;s finest homes, businesses, and public spaces
           </p>
           <div className="w-8 h-px bg-gold mx-auto mb-6" />
           <p className="font-body text-sm text-muted">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -133,7 +133,7 @@ export default async function HomePage() {
                 Selected Works
               </h2>
               <p className="font-body text-mist max-w-2xl mx-auto">
-                A curated selection of decorative finishes, murals, and plaster work customized to our clients&apos; tastes across Houston&apos;s finest homes.
+                A curated selection of decorative finishes, murals, and plaster work customized to our clients&apos; tastes across Houston&apos;s finest homes, businesses, and public spaces.
               </p>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -44,7 +44,7 @@ export default async function PortfolioPage() {
             Portfolio
           </h1>
           <p className="font-editorial text-xl md:text-2xl text-mist max-w-2xl mx-auto mb-6">
-            A curated collection of decorative finishes across Houston&apos;s finest homes
+            A curated collection of decorative finishes across Houston&apos;s finest homes, businesses, and public spaces
           </p>
           <div className="w-8 h-px bg-gold mx-auto mb-6" />
           <p className="font-body text-sm text-muted">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -24,7 +24,7 @@ export function Footer({ services, areas }: FooterProps = {}) {
           <div>
             <p className="font-display text-2xl text-cream mb-3">Misha Creations</p>
             <p className="font-body text-sm leading-relaxed mb-4">
-              Luxury decorative finishes, wall murals, and Venetian plaster for Houston&apos;s finest homes.
+              Luxury decorative finishes, wall murals, and Venetian plaster for Houston&apos;s finest homes, businesses, and public spaces.
               25+ years of artistic excellence.
             </p>
           </div>


### PR DESCRIPTION
## Summary

Append **", businesses, and public spaces"** after "Houston's finest homes" in five generic cross-audience locations. Reflects that Misha's portfolio includes commercial commissions (Houston Zoo, Rainforest Café, Katy Mills Mall, Captain Brad's, law firm themescape) in addition to residential.

## Changes

| File | What |
|---|---|
| `src/app/page.tsx` | Home "Selected Works" subtitle — the operator's explicit ask |
| `src/app/gallery/page.tsx` | Gallery hero subtitle |
| `src/app/portfolio/page.tsx` | Portfolio hero subtitle |
| `src/components/Footer.tsx` | Footer tagline (renders on every page) |
| `src/app/about/page.tsx` | About page meta description (title + OG) |

## Deliberately NOT touched (residential/luxury-home focus preserved)

- All service-page metas and body copy in `src/lib/constants.ts` (Venetian Plaster, Murals, Ceilings, Trompe l'Oeil, Themed Rooms, Skyscapes, Faux Finishes, Modello — all explicitly target Houston luxury homes)
- Portfolio meta description (River Oaks / Memorial / Tanglewood neighborhood-specific)
- `decorative-painting-houston` landing page (luxury-home SEO target)
- Blog post metas and titles ("A Guide to Venetian Lime Plaster for Houston **Luxury Homes**" — guide aimed at residential clients)
- Process page meta description
- All **"Trusted by homeowners in …"** social-proof strips on portfolio, recent-projects, gallery, and the `NeighborhoodStrip` component — explicitly homeowner-framed

Per the operator's rule: *"Except where we are focusing on residential, luxury homes, or homeowners."*

## Test plan
- [x] `npx next build` — passes
- [ ] Preview deploy review (confirm footer + Selected Works read correctly on home)
- [ ] Production /, /about, /gallery, /portfolio verified after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)