### PR TITLE
fix(inquiry): revise error message + treat GHL failures as non-fatal

### DIFF
--- a/src/app/api/inquiry/route.ts
+++ b/src/app/api/inquiry/route.ts
@@ -155,9 +155,17 @@ export async function POST(req: NextRequest) {
 
   // ── Response ─────────────────────────────────────────────────────────────────
 
-  if (errors.some(e => e.startsWith('ghl_contact'))) {
+  // Fail the submission only if the notification email to Misha also failed —
+  // the email is our lead-capture source of truth. GHL CRM upsert is secondary
+  // tracking; log failures but do not block the user's success response when
+  // Misha has already received the inquiry by email.
+  if (errors.some(e => e.startsWith('notification_email'))) {
     return NextResponse.json(
-      { error: 'Form submission could not be processed. Please try again or email us directly.', errors },
+      {
+        error:
+          'Form submission could not be processed. Please try again, e-mail us directly at misha@mishacreations.com or call/text Misha at 281-650-0500. We are sorry for the inconvenience.',
+        errors,
+      },
       { status: 500 }
     );
   }

--- a/src/app/inquire/page.tsx
+++ b/src/app/inquire/page.tsx
@@ -92,7 +92,7 @@ export default function InquirePage() {
 
       setSubmitted(true)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Something went wrong. Please try again or call to reach us directly.')
+      setError(err instanceof Error ? err.message : 'Form submission could not be processed. Please try again, e-mail us directly at misha@mishacreations.com or call/text Misha at 281-650-0500. We are sorry for the inconvenience.')
     } finally {
       setSending(false)
     }


### PR DESCRIPTION
Fixes #61

## Summary

Two changes to address the online inquiry form failing at `https://mishacreations.com/inquire`:

### 1. Error message revised (operator's explicit ask)

**Before:**
> Form submission could not be processed. Please try again or email us directly.

**After:**
> Form submission could not be processed. Please try again, e-mail us directly at misha@mishacreations.com or call/text Misha at 281-650-0500. We are sorry for the inconvenience.

Applied to both the server response (`route.ts`) and the client-side catch fallback (`inquire/page.tsx`) so the revised copy shows up regardless of whether the failure is a 500 response or a network-level throw.

### 2. GHL failures no longer break the form

Root-cause diagnosis: the endpoint was returning a 500 response whenever the **secondary** GoHighLevel (GHL) CRM contact upsert failed — even though the **primary** notification email to Misha already succeeded. Users saw the form as broken while Misha already had the inquiry in her inbox.

**Changed behavior:** the 500 only fires if the `notification_email` step fails. GHL failures (contact upsert, opportunity creation) are logged server-side but the user gets a success response because the lead-capture source of truth (email to Misha) went through.

## Follow-up (separate)

The GHL integration failing is still a real bug — the CRM side of the funnel isn't capturing leads. Likely causes:
- `GHL_API_KEY` env var expired or missing on Vercel
- `GHL_LOCATION_ID` env var missing
- GHL API v2 endpoint change or rate limit

Worth verifying the Vercel env vars for `misha-website` under **Settings → Environment Variables** and/or rotating the GHL API key. That's a separate task — this PR just prevents the user-facing form from being held hostage to CRM uptime.

## Test plan
- [x] `npx next build` — passes
- [ ] Preview deploy — submit test inquiry, verify:
  - Success path returns "Thank You" page
  - If I temporarily break `RESEND_API_KEY`, user sees the new error copy with phone + email
- [ ] Production verified after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)