### PR TITLE
fix(ghl): handle duplicate-contact 400 by updating existing contact

### DIFF
--- a/src/lib/ghl-client.ts
+++ b/src/lib/ghl-client.ts
@@ -86,13 +86,59 @@ export async function upsertContact(payload: GHLContactPayload): Promise<GHLCont
     body: JSON.stringify(body),
   });
 
-  if (!res.ok) {
-    const err = await res.text();
-    throw new Error(`GHL upsertContact failed (${res.status}): ${err}`);
+  // Happy path — new contact created
+  if (res.ok) {
+    const data = await res.json();
+    return data.contact as GHLContact;
   }
 
-  const data = await res.json();
-  return data.contact as GHLContact;
+  // Duplicate contact — some GHL locations reject POST on existing email
+  // and return 400 with the existing contactId in meta. Update tags +
+  // custom fields on the existing contact so the inquiry still lands.
+  if (res.status === 400) {
+    const errBody = await res.json().catch(() => null);
+    const existingId: string | undefined = errBody?.meta?.contactId;
+    const isDuplicate = /duplicat/i.test(errBody?.message || '');
+
+    if (existingId && isDuplicate) {
+      // Fire in parallel — tag application + custom-field update
+      await Promise.all([
+        payload.tags?.length ? addTags(existingId, payload.tags) : Promise.resolve(),
+        customFields.length > 0 ? updateContactCustomFields(existingId, customFields) : Promise.resolve(),
+      ]);
+
+      return {
+        id: existingId,
+        email: payload.email,
+        firstName: payload.firstName,
+        lastName: payload.lastName,
+      } as GHLContact;
+    }
+
+    throw new Error(`GHL upsertContact failed (400): ${JSON.stringify(errBody)}`);
+  }
+
+  const errText = await res.text();
+  throw new Error(`GHL upsertContact failed (${res.status}): ${errText}`);
+}
+
+// Update only custom fields on an existing contact (non-destructive — does
+// not touch name, email, phone, etc. which may have cleaner data than what
+// the form captured).
+async function updateContactCustomFields(
+  contactId: string,
+  customFields: Array<{ id: string; field_value: string }>
+): Promise<void> {
+  const res = await fetch(`${GHL_BASE}/contacts/${contactId}`, {
+    method: 'PUT',
+    headers: headers(),
+    body: JSON.stringify({ customFields }),
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`GHL updateContactCustomFields failed (${res.status}): ${err}`);
+  }
 }
 
 export async function addTags(contactId: string, tags: string[]): Promise<void> {


### PR DESCRIPTION
## Context

Discovered during issue #61 diagnosis after the GHL API key was rotated:

```
ghl_contact: Error: GHL upsertContact failed (400):
{"statusCode":400,"message":"This location does not allow duplicated
contacts.","meta":{"contactName":"...","contactId":"HcL7AIjU...",
"matchingField":"email"},"traceId":"..."}
```

The GHL location is configured to reject `POST /contacts/` for an email that already exists. Previously this tripped the `ghl_contact` failure path. With PR #62 that's no longer user-blocking (email is the source of truth), but it still means **returning inquirers silently drop out of the CRM funnel** — tags don't get applied, opportunities don't get created.

## Fix

When the GHL response is `400` with `message` matching `duplicat` and a `meta.contactId` is present:

1. Apply the requested **tags** to the existing contact (`addTags`)
2. Write the requested **custom fields** to the existing contact (`PUT /contacts/:id`)
3. Return a synthetic `GHLContact` with the existing id so `createOpportunity()` still runs

### Non-destructive by design

- Does **not** overwrite `firstName` / `lastName` / `phone` / `email` on the existing contact — those may have been enriched by prior CRM edits and shouldn't be clobbered by whatever the inquiry form captured
- Only writes what the form explicitly captures: tags + custom fields (`inquiry_type`, `project_timeline`, `source_site`, etc.)

### Downstream effect

Returning inquiries now correctly surface in GHL as **new opportunities against the existing contact record** — the right CRM shape for re-engagement rather than duplicate contact records.

## Test plan

- [x] `npx next build` — passes
- [ ] Once merged, submit a test inquiry with an email already known to GHL. Expected: HTTP 200 success, new opportunity appears under the existing contact, new tags applied.
- [ ] Submit a test inquiry with a new email. Expected: HTTP 200 success, new contact created, new opportunity.

## Separate follow-up (not in this PR)

Form submissions are still 500ing end-to-end because **`mishacreations.com` isn't verified in Resend** — both notification and confirmation emails fail domain verification. That requires a DNS change in the domain provider, not a code change. Once the domain is verified, this PR + PR #62 together make the form resilient to both email and CRM failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)