### PR TITLE
feat(projects): render per-project testimonial on /projects/[slug]

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -117,6 +117,34 @@ export default async function ProjectPage({
         </div>
       </section>
 
+      {/* Testimonial — rendered only when a quote is present */}
+      {project.testimonial?.quote && (
+        <section className="bg-warm py-16 md:py-24">
+          <div className="max-w-3xl mx-auto px-5 text-center">
+            <p className="font-body text-xs uppercase tracking-[0.2em] text-gold mb-6">
+              Client Testimonial
+            </p>
+            <blockquote className="font-editorial text-xl md:text-2xl text-cream italic leading-relaxed mb-6">
+              &ldquo;{project.testimonial.quote}&rdquo;
+            </blockquote>
+            {(project.testimonial.attribution || project.testimonial.role) && (
+              <div className="flex items-baseline justify-center gap-3 flex-wrap">
+                {project.testimonial.attribution && (
+                  <p className="font-body text-sm text-mist">
+                    &mdash; {project.testimonial.attribution}
+                  </p>
+                )}
+                {project.testimonial.role && (
+                  <p className="font-body text-xs text-mist/70 italic">
+                    {project.testimonial.role}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+
       {/* Back nav */}
       <section className="bg-warm py-8">
         <div className="max-w-7xl mx-auto px-5 flex flex-wrap gap-4 justify-center">

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -374,6 +374,13 @@ export async function getNavData(): Promise<{
    Project Galleries
    ═══════════════════════════════════════════════════════════════ */
 
+export interface StudioProjectTestimonial {
+  quote?: string
+  attribution?: string
+  role?: string
+  date?: string
+}
+
 export interface StudioProject {
   _id: string
   title: string
@@ -384,13 +391,15 @@ export interface StudioProject {
   displayOrder?: number
   pieces: PortfolioPiece[]
   pieceCount: number
+  testimonial?: StudioProjectTestimonial
 }
 
 const PROJECT_FIELDS = `
   _id, title, slug, category, description, displayOrder,
   heroImage { asset, hotspot, alt, "lqip": asset->metadata.lqip },
   "pieces": pieces[]->{ ${PIECE_FIELDS} },
-  "pieceCount": count(pieces)
+  "pieceCount": count(pieces),
+  testimonial { quote, attribution, role, date }
 `
 
 /** All published projects for /recent-projects listing */


### PR DESCRIPTION
## Summary

Pulls the new `testimonial` object from `studioProject` (added in misha-studio-site PR #51) and renders a centered testimonial section on the project gallery page, between the image grid and the back nav.

Fills in the rendering side of the request: https://github.com/rayrich01/misha-studio-site/pull/51

## Rendering rules

- Only renders when `testimonial.quote` is non-empty — empty/missing = no block
- `attribution` and `role` render only if present, each independent
- Quote styled editorial-italic to match the homepage testimonial pattern
- Warm background section visually separates it from the image grid

## Changes

- `src/lib/queries.ts`
  - New `StudioProjectTestimonial` interface
  - `StudioProject` gains optional `testimonial` field
  - `PROJECT_FIELDS` GROQ extended with `testimonial { quote, attribution, role, date }`
- `src/app/projects/[slug]/page.tsx`
  - New `<section>` between image grid and back nav; renders conditionally on quote presence

## Dependency order

Merge after misha-studio-site PR #51 so the schema exists first. That said, this PR is safe to merge before — Sanity doesn't enforce schema on reads. If `testimonial` doesn't exist on a project doc, the GROQ returns `null` and the section just doesn't render.

## Test plan

- [x] `npx next build` — passes
- [ ] Preview deploy review — verify layout on an existing project page (will show no testimonial section since no project has a quote yet)
- [ ] After schema merge: Misha adds a test testimonial to one project in the Studio → testimonial block appears within 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)