### PR TITLE
docs(governance): annotate shared-flag queries in queries.ts (companion to hardening PR #66)

### DIFF
--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -59,6 +59,11 @@ export interface MainSiteSettings {
 }
 
 /** Misha Select pieces — curated gallery for main site */
+// ⚠ Shared-flag consumer — reads `isMishaSelect`. Other consumers of this
+// flag: getFeaturedPieces() (below), getRelatedPieces() (below), and
+// misha-studio-site/src/lib/studio-queries.ts getMishaSelectPieces().
+// Before any batch mutation to isMishaSelect, run the consumer-diff checklist in
+// _ttp/CR-HOMEPAGE-FEATURED-001-GOVERNANCE-BREACH/hardening.md.
 export async function getMishaSelectPieces(limit = 12): Promise<PortfolioPiece[]> {
   return sanityClient.fetch(`
     *[_type == "portfolioPiece" && published == true && coalesce(archived, false) != true && isMishaSelect == true]
@@ -96,6 +101,8 @@ export async function getPiecesByLocation(location: string, limit = 4): Promise<
 }
 
 /** Featured portfolio pieces for gallery hero */
+// ⚠ Shared-flag consumer — combines `isMishaSelect` AND `isFeatured`. Mutating
+// either flag affects this query. See hardening packet before batch edits.
 export async function getFeaturedPieces(limit = 6): Promise<PortfolioPiece[]> {
   return sanityClient.fetch(`
     *[_type == "portfolioPiece" && published == true && coalesce(archived, false) != true
@@ -120,6 +127,9 @@ export async function getAllPortfolioSlugs(): Promise<string[]> {
 }
 
 /** Related pieces from same category, excluding current */
+// ⚠ Shared-flag consumer — reads `isMishaSelect` AND `category`. A piece
+// gains/loses a "Related" placement on sibling piece pages when either flips.
+// See hardening packet.
 export async function getRelatedPieces(category: string, excludeId: string, limit = 3): Promise<PortfolioPiece[]> {
   return sanityClient.fetch(`
     *[_type == "portfolioPiece" && published == true && coalesce(archived, false) != true
@@ -153,6 +163,8 @@ export async function getMainSiteSettings(): Promise<MainSiteSettings | null> {
 }
 
 /** Homepage hero piece (fallback if no mainSiteSettings) */
+// ⚠ Shared-flag consumer — reads `isFeatured`. Flipping this flag on a piece
+// can replace the full-screen home-page hero background. See hardening packet.
 export async function getHomepageHero(): Promise<PortfolioPiece | null> {
   return sanityClient.fetch(`
     *[_type == "portfolioPiece" && published == true && isFeatured == true]


### PR DESCRIPTION
## Comments-only PR

Follows up the hardening packet (PR #66, merged) and mirrors the studio-site annotations (PR #52, merged). Adds inline warning comments above every GROQ fetch in `src/lib/queries.ts` that reads a shared mutation-risk flag. Each comment points readers at the hardening packet for the pre-mutation consumer-diff checklist.

## Scope compliance

- ✅ **Comments only** — no code logic, no GROQ string edits
- ✅ **Zero runtime behavior change** — build passes, ISR behavior identical
- ✅ **Zero Sanity data mutation**
- ✅ **Zero schema change**
- ✅ **Zero query behavior change** — GROQ strings untouched; only comments above declarations

## Functions annotated

| Function | Shared flag read | Why it matters |
|---|---|---|
| `getMishaSelectPieces()` | `isMishaSelect` | Same flag backs `/select` (private) + `/recent-projects` + `/areas/[slug]` fallback. Before CR-HOMEPAGE-FEATURED-001 it also backed the home-page grid. |
| `getFeaturedPieces()` | `isMishaSelect` AND `isFeatured` | Combines both flags to drive the portfolio/gallery hero rows. Mutating either triggers cross-surface drift. |
| `getRelatedPieces()` | `isMishaSelect` AND `category` | A piece gains/loses a "Related" placement on sibling piece pages when either flips. |
| `getHomepageHero()` | `isFeatured` | Flipping this can replace the full-screen home-page hero background. |

Each comment explicitly names the related consumers and cross-references `_ttp/CR-HOMEPAGE-FEATURED-001-GOVERNANCE-BREACH/hardening.md` (in main since PR #66).

## Test plan

- [x] `npx next build` — passes
- [ ] Preview deploy renders identically to main (comments are not shipped to the browser)
- [ ] No Sanity data round-trip needed

## Not included in this PR

- Remediation code (splitting `isMishaSelect` / `isFeatured`, adding `mainSiteSettings.featuredPieces[]`, etc.) — deferred to a future packet with separate authorization.
- `scripts/consumer-diff.mjs` automation — deferred.
- `studioProject` flag follow-up — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)