### PR TITLE
Fix Sanity CDN cache + FAQ null safety on service pages

### DIFF
--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -89,7 +89,7 @@ export default async function ServicePage({ params }: PageProps) {
       answer: `Absolutely. Misha creates physical finish samples for your approval before any brushwork begins. You see and touch the exact finish that will be applied in your home. No surprises on install day.`,
     },
   ]
-  const finishFaqs = enrichment ? [...baseFaqs, ...enrichment.extraFaqs] : baseFaqs
+  const finishFaqs = enrichment ? [...baseFaqs, ...(enrichment.extraFaqs || [])] : baseFaqs
 
   const serviceSchema = {
     '@context': 'https://schema.org',

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -10,7 +10,7 @@ export const sanityClient = createClient({
   projectId,
   dataset,
   apiVersion: '2026-02-19',
-  useCdn: true,
+  useCdn: false,
 })
 
 const builder = createImageUrlBuilder(sanityClient)


### PR DESCRIPTION
Studio edits to FAQs were not reflecting. Two fixes: disabled CDN cache, added null safety on extraFaqs spread.