### PR TITLE
Add all page schemas to Sanity Studio editor

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,156 +1,20 @@
-import { defineConfig, defineType, defineField } from 'sanity'
+import { defineConfig } from 'sanity'
 import { structureTool } from 'sanity/structure'
 import { visionTool } from '@sanity/vision'
 
-/* ── About Page ─────────────────────────────────────────── */
-const aboutPage = defineType({
-  name: 'aboutPage',
-  title: 'About Page',
-  type: 'document',
-  fields: [
-    defineField({ name: 'headline', type: 'string', title: 'Headline' }),
-    defineField({ name: 'subheadline', type: 'string', title: 'Subheadline' }),
-    defineField({ name: 'storyText', type: 'text', title: 'Story (main paragraph)', rows: 6 }),
-    defineField({ name: 'artOfLightText', type: 'text', title: 'Art of Light section', rows: 4 }),
-    defineField({ name: 'portraitImage', type: 'image', title: 'Portrait Photo', options: { hotspot: true } }),
-    defineField({
-      name: 'processSteps', type: 'array', title: 'Process Steps',
-      of: [{ type: 'object', fields: [
-        defineField({ name: 'number', type: 'string', title: 'Step Number' }),
-        defineField({ name: 'title', type: 'string', title: 'Step Title' }),
-        defineField({ name: 'text', type: 'text', title: 'Step Description' }),
-      ]}],
-    }),
-    defineField({
-      name: 'trainingSchools', type: 'array', title: 'Training Schools & Ateliers',
-      of: [{ type: 'object', fields: [
-        defineField({ name: 'name', type: 'string', title: 'School / Atelier Name' }),
-        defineField({ name: 'location', type: 'string', title: 'Location (optional)' }),
-        defineField({ name: 'description', type: 'text', title: 'What was studied', rows: 2 }),
-      ]}],
-    }),
-    defineField({
-      name: 'notablePortfolio', type: 'array', title: 'Notable Portfolio & Commissions',
-      of: [{ type: 'object', fields: [
-        defineField({ name: 'title', type: 'string', title: 'Project / Commission Title' }),
-        defineField({ name: 'description', type: 'text', title: 'Description', rows: 2 }),
-        defineField({ name: 'url', type: 'url', title: 'External Link (optional)' }),
-      ]}],
-    }),
-    defineField({
-      name: 'artners', type: 'array', title: 'Artners — Collaborating Master Artists',
-      of: [{ type: 'object', fields: [
-        defineField({ name: 'name', type: 'string', title: 'Artner Name' }),
-        defineField({ name: 'specialty', type: 'string', title: 'Specialty / Role' }),
-        defineField({ name: 'notes', type: 'text', title: 'Notes (optional)', rows: 2 }),
-      ]}],
-    }),
-    defineField({ name: 'credentials', type: 'array', title: 'Credentials / Recognition', of: [{ type: 'string' }] }),
-    defineField({ name: 'seoTitle', type: 'string', title: 'SEO Title' }),
-    defineField({ name: 'seoDescription', type: 'text', title: 'SEO Description', rows: 2 }),
-  ],
-  preview: { prepare: () => ({ title: 'About Page' }) },
-})
+import aboutPage from './sanity/schemas/aboutPage'
+import areaPage from './sanity/schemas/areaPage'
+import blogPost from './sanity/schemas/blogPost'
+import faqPage from './sanity/schemas/faqPage'
+import finishCategory from './sanity/schemas/finishCategory'
+import mainSiteSettings from './sanity/schemas/mainSiteSettings'
+import portfolioPiece from './sanity/schemas/portfolioPiece'
+import processPage from './sanity/schemas/processPage'
+import servicePage from './sanity/schemas/servicePage'
+import servicesHubPage from './sanity/schemas/servicesHubPage'
+import siteGlobals from './sanity/schemas/siteGlobals'
+import studioProject from './sanity/schemas/studioProject'
 
-/* ── Services Hub Page ──────────────────────────────────── */
-const servicesHubPage = defineType({
-  name: 'servicesHubPage',
-  title: 'Services Hub Page',
-  type: 'document',
-  fields: [
-    defineField({
-      name: 'seo', title: 'SEO', type: 'object',
-      fields: [
-        defineField({ name: 'metaTitle', type: 'string', title: 'Meta Title' }),
-        defineField({ name: 'metaDescription', type: 'text', title: 'Meta Description', rows: 3 }),
-      ],
-    }),
-    defineField({ name: 'heroHeadline', type: 'string', title: 'Hero Headline' }),
-    defineField({ name: 'heroSubtext', type: 'text', title: 'Hero Subtext', rows: 2 }),
-    defineField({ name: 'introText', type: 'text', title: 'Intro Paragraph', rows: 4 }),
-    defineField({ name: 'trustHeading', type: 'string', title: 'Trust Section Heading' }),
-    defineField({ name: 'trustPoints', type: 'array', title: 'Trust Points', of: [{ type: 'string' }] }),
-    defineField({ name: 'processHeading', type: 'string', title: 'Process Section Heading' }),
-    defineField({
-      name: 'hubFaqs', title: 'Hub FAQs', type: 'array',
-      of: [{ type: 'object', fields: [
-        defineField({ name: 'question', type: 'string', title: 'Question', validation: (Rule) => Rule.required() }),
-        defineField({ name: 'answer', type: 'text', title: 'Answer', rows: 4, validation: (Rule) => Rule.required() }),
-      ], preview: { select: { title: 'question' } } }],
-    }),
-    defineField({ name: 'ctaHeadline', type: 'string', title: 'CTA Headline' }),
-    defineField({ name: 'ctaBody', type: 'text', title: 'CTA Body', rows: 3 }),
-  ],
-  preview: { prepare: () => ({ title: 'Services Hub Page' }) },
-})
-
-/* ── Service Page (individual) ──────────────────────────── */
-const servicePage = defineType({
-  name: 'servicePage',
-  title: 'Service Page',
-  type: 'document',
-  fields: [
-    defineField({ name: 'slug', title: 'URL Slug', type: 'slug', description: 'URL path, e.g. "venetian-lime-plaster"', validation: (Rule) => Rule.required() }),
-    defineField({ name: 'categoryId', title: 'Category ID', type: 'string', description: 'Maps to portfolioPiece.category value', validation: (Rule) => Rule.required() }),
-    defineField({ name: 'title', title: 'Display Title', type: 'string', validation: (Rule) => Rule.required() }),
-    defineField({ name: 'h1', title: 'Page H1', type: 'string' }),
-    defineField({ name: 'cardDescription', title: 'Card Description', type: 'text', rows: 2, description: 'One-liner shown on the services hub page' }),
-    defineField({
-      name: 'seo', title: 'SEO', type: 'object',
-      fields: [
-        defineField({ name: 'metaTitle', type: 'string', title: 'Meta Title' }),
-        defineField({ name: 'metaDescription', type: 'text', title: 'Meta Description', rows: 3 }),
-      ],
-    }),
-    defineField({
-      name: 'intro', title: 'Intro Section', type: 'object',
-      fields: [
-        defineField({ name: 'heading', type: 'string', title: 'Heading' }),
-        defineField({ name: 'paragraphs', type: 'array', title: 'Paragraphs', of: [{ type: 'text' }] }),
-      ],
-    }),
-    defineField({
-      name: 'process', title: 'Process Section', type: 'object',
-      fields: [
-        defineField({ name: 'heading', type: 'string', title: 'Heading' }),
-        defineField({
-          name: 'steps', type: 'array', title: 'Steps',
-          of: [{ type: 'object', fields: [
-            defineField({ name: 'name', type: 'string', title: 'Step Name' }),
-            defineField({ name: 'desc', type: 'text', title: 'Description', rows: 3 }),
-          ], preview: { select: { title: 'name' } } }],
-        }),
-      ],
-    }),
-    defineField({
-      name: 'trust', title: 'Trust Section', type: 'object',
-      fields: [
-        defineField({ name: 'heading', type: 'string', title: 'Heading' }),
-        defineField({ name: 'points', type: 'array', title: 'Trust Points', of: [{ type: 'string' }] }),
-      ],
-    }),
-    defineField({
-      name: 'extraFaqs', title: 'FAQs', type: 'array',
-      of: [{ type: 'object', fields: [
-        defineField({ name: 'question', type: 'string', title: 'Question', validation: (Rule) => Rule.required() }),
-        defineField({ name: 'answer', type: 'text', title: 'Answer', rows: 4, validation: (Rule) => Rule.required() }),
-      ], preview: { select: { title: 'question' } } }],
-    }),
-    defineField({
-      name: 'relatedServices', title: 'Related Services', type: 'array',
-      of: [{ type: 'object', fields: [
-        defineField({ name: 'slug', type: 'string', title: 'Service Slug' }),
-        defineField({ name: 'label', type: 'string', title: 'Display Label' }),
-      ], preview: { select: { title: 'label' } } }],
-    }),
-    defineField({ name: 'areaContext', title: 'Area Context Line', type: 'text', rows: 2 }),
-    defineField({ name: 'sortOrder', title: 'Sort Order', type: 'number' }),
-  ],
-  preview: { select: { title: 'title' } },
-  orderings: [{ title: 'Sort Order', name: 'sortOrder', by: [{ field: 'sortOrder', direction: 'asc' }] }],
-})
-
-/* ── Studio Config ──────────────────────────────────────── */
 export default defineConfig({
   name: 'misha-website',
   title: 'Misha Creations — Website Editor',
@@ -159,6 +23,22 @@ export default defineConfig({
   basePath: '/studio',
   plugins: [structureTool(), visionTool()],
   schema: {
-    types: [aboutPage, servicesHubPage, servicePage],
+    types: [
+      // Page Content
+      mainSiteSettings,
+      aboutPage,
+      faqPage,
+      processPage,
+      servicesHubPage,
+      servicePage,
+      areaPage,
+      blogPost,
+      siteGlobals,
+
+      // Portfolio & Gallery
+      portfolioPiece,
+      finishCategory,
+      studioProject,
+    ],
   },
 })

--- a/sanity/schemas/aboutPage.ts
+++ b/sanity/schemas/aboutPage.ts
@@ -1,0 +1,58 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'aboutPage',
+  title: 'About Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'homepageHero',
+      title: 'Homepage Hero Image',
+      type: 'reference',
+      to: [{ type: 'portfolioPiece' }],
+      description: 'The portfolio piece whose hero image appears as the full-screen homepage background',
+    }),
+    defineField({ name: 'headline',        type: 'string',  title: 'Headline' }),
+    defineField({ name: 'subheadline',     type: 'string',  title: 'Subheadline' }),
+    defineField({ name: 'storyText',       type: 'text',    title: 'Story (main paragraph)', rows: 6 }),
+    defineField({ name: 'artOfLightText',  type: 'text',    title: 'Art of Light section',   rows: 4 }),
+    defineField({ name: 'portraitImage',   type: 'image',   title: 'Portrait Photo', options: { hotspot: true } }),
+    defineField({ name: 'processSteps',    type: 'array',   title: 'Process Steps',
+      of: [{ type: 'object', fields: [
+        defineField({ name: 'number', type: 'string', title: 'Step Number' }),
+        defineField({ name: 'title',  type: 'string', title: 'Step Title' }),
+        defineField({ name: 'text',   type: 'text',   title: 'Step Description', validation: undefined }),
+      ]}]
+    }),
+    defineField({ name: 'trainingSchools', type: 'array',   title: 'Training Schools & Ateliers',
+      description: 'Formal training. Add new entries here as they are supplied — the About page grows automatically.',
+      of: [{ type: 'object', fields: [
+        defineField({ name: 'name',        type: 'string', title: 'School / Atelier Name' }),
+        defineField({ name: 'location',    type: 'string', title: 'Location (optional)' }),
+        defineField({ name: 'description', type: 'text',   title: 'What was studied', rows: 2 }),
+      ]}]
+    }),
+    defineField({ name: 'notablePortfolio', type: 'array',  title: 'Notable Portfolio & Commissions',
+      description: 'Named projects, productions, or commissions worth listing distinctly from the general credentials bullets.',
+      of: [{ type: 'object', fields: [
+        defineField({ name: 'title',       type: 'string', title: 'Project / Commission Title' }),
+        defineField({ name: 'description', type: 'text',   title: 'Description', rows: 2 }),
+        defineField({ name: 'url',         type: 'url',    title: 'External Link (optional)' }),
+      ]}]
+    }),
+    defineField({ name: 'artners', type: 'array', title: 'Artners — Collaborating Master Artists',
+      description: "Peer artists Misha collaborates with on large jobs. She credits them as 'Artners.'",
+      of: [{ type: 'object', fields: [
+        defineField({ name: 'name',      type: 'string', title: 'Artner Name' }),
+        defineField({ name: 'specialty', type: 'string', title: 'Specialty / Role' }),
+        defineField({ name: 'notes',     type: 'text',   title: 'Notes (optional)', rows: 2 }),
+      ]}]
+    }),
+    defineField({ name: 'credentials',     type: 'array',   title: 'Credentials / Recognition',
+      of: [{ type: 'string' }]
+    }),
+    defineField({ name: 'seoTitle',        type: 'string',  title: 'SEO Title' }),
+    defineField({ name: 'seoDescription',  type: 'text',    title: 'SEO Description', rows: 2 }),
+  ],
+  preview: { prepare: () => ({ title: 'About Page' }) }
+})

--- a/sanity/schemas/areaPage.ts
+++ b/sanity/schemas/areaPage.ts
@@ -1,0 +1,117 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'areaPage',
+  title: 'Area Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'slug',
+      title: 'URL Slug',
+      type: 'slug',
+      description: 'URL path segment, e.g. "river-oaks-luxury-murals"',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'name',
+      title: 'Area Name',
+      type: 'string',
+      description: 'Display name, e.g. "River Oaks"',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'seo',
+      title: 'SEO',
+      type: 'object',
+      fields: [
+        defineField({ name: 'metaTitle', type: 'string', title: 'Meta Title' }),
+        defineField({ name: 'metaDescription', type: 'text', title: 'Meta Description', rows: 3 }),
+      ],
+    }),
+    defineField({
+      name: 'h1',
+      title: 'Page H1',
+      type: 'string',
+    }),
+    defineField({
+      name: 'description',
+      title: 'Intro Description',
+      type: 'text',
+      rows: 4,
+    }),
+    defineField({
+      name: 'featuredCategories',
+      title: 'Featured Categories',
+      type: 'array',
+      of: [{ type: 'string' }],
+      description: 'Category IDs to feature (e.g. "venetian-plaster", "wall-murals")',
+    }),
+    defineField({
+      name: 'categoryOffset',
+      title: 'Category Offset',
+      type: 'number',
+      description: 'Offset for portfolio piece display',
+    }),
+    defineField({
+      name: 'popularFinishes',
+      title: 'Popular Finishes',
+      type: 'array',
+      of: [{ type: 'string' }],
+      description: 'Display names of popular finishes in this area',
+    }),
+    defineField({
+      name: 'faqAnswers',
+      title: 'Base FAQ Answers',
+      type: 'object',
+      description: 'Answers for the 3 standard area FAQs (serve, cost, popular)',
+      fields: [
+        defineField({ name: 'serve', type: 'text', title: 'Does Misha serve this area?', rows: 3 }),
+        defineField({ name: 'cost', type: 'text', title: 'How much does it cost?', rows: 3 }),
+        defineField({ name: 'popular', type: 'text', title: 'What finishes are popular here?', rows: 3 }),
+      ],
+    }),
+    defineField({
+      name: 'extraFaqs',
+      title: 'Additional FAQs',
+      type: 'array',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({ name: 'question', type: 'string', title: 'Question', validation: (Rule) => Rule.required() }),
+          defineField({ name: 'answer', type: 'text', title: 'Answer', rows: 4, validation: (Rule) => Rule.required() }),
+        ],
+        preview: { select: { title: 'question' } },
+      }],
+    }),
+    defineField({
+      name: 'nearbyAreas',
+      title: 'Nearby Areas',
+      type: 'array',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({ name: 'slug', type: 'string', title: 'Area Slug' }),
+          defineField({ name: 'name', type: 'string', title: 'Area Name' }),
+        ],
+        preview: { select: { title: 'name' } },
+      }],
+    }),
+    defineField({
+      name: 'trustPoints',
+      title: 'Trust Points',
+      type: 'array',
+      of: [{ type: 'string' }],
+    }),
+    defineField({
+      name: 'sortOrder',
+      title: 'Sort Order',
+      type: 'number',
+    }),
+  ],
+  preview: {
+    select: { title: 'name' },
+  },
+  orderings: [
+    { title: 'Sort Order', name: 'sortOrder', by: [{ field: 'sortOrder', direction: 'asc' }] },
+  ],
+})

--- a/sanity/schemas/blogPost.ts
+++ b/sanity/schemas/blogPost.ts
@@ -1,0 +1,53 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'blogPost',
+  title: 'Blog Post',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: { source: 'title', maxLength: 96 },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'seo',
+      title: 'SEO',
+      type: 'object',
+      fields: [
+        defineField({ name: 'metaTitle', type: 'string', title: 'Meta Title' }),
+        defineField({ name: 'metaDescription', type: 'text', title: 'Meta Description', rows: 3 }),
+      ],
+    }),
+    defineField({
+      name: 'body',
+      title: 'Body',
+      type: 'array',
+      of: [
+        { type: 'block' },
+        { type: 'image', options: { hotspot: true } },
+      ],
+    }),
+    defineField({
+      name: 'publishedAt',
+      title: 'Published At',
+      type: 'datetime',
+    }),
+    defineField({ name: 'ctaHeadline', type: 'string', title: 'CTA Headline' }),
+    defineField({ name: 'ctaBody', type: 'text', title: 'CTA Body', rows: 3 }),
+  ],
+  preview: {
+    select: { title: 'title', subtitle: 'publishedAt' },
+  },
+  orderings: [
+    { title: 'Published', name: 'published', by: [{ field: 'publishedAt', direction: 'desc' }] },
+  ],
+})

--- a/sanity/schemas/faqPage.ts
+++ b/sanity/schemas/faqPage.ts
@@ -1,0 +1,31 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'faqPage',
+  title: 'FAQ Page',
+  type: 'document',
+  fields: [
+    defineField({ name: 'headline',       type: 'string', title: 'Headline' }),
+    defineField({ name: 'subheadline',    type: 'string', title: 'Subheadline' }),
+    defineField({
+      name: 'faqs',
+      type: 'array',
+      title: 'FAQ Items',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({ name: 'question', type: 'string', title: 'Question', validation: (Rule) => Rule.required() }),
+          defineField({ name: 'answer',   type: 'text',   title: 'Answer',   rows: 4, validation: (Rule) => Rule.required() }),
+        ],
+        preview: {
+          select: { title: 'question' },
+        },
+      }],
+    }),
+    defineField({ name: 'ctaHeadline',    type: 'string', title: 'CTA Headline' }),
+    defineField({ name: 'ctaText',        type: 'text',   title: 'CTA Body Text', rows: 3 }),
+    defineField({ name: 'seoTitle',       type: 'string', title: 'SEO Title' }),
+    defineField({ name: 'seoDescription', type: 'text',   title: 'SEO Description', rows: 2 }),
+  ],
+  preview: { prepare: () => ({ title: 'FAQ Page' }) },
+})

--- a/sanity/schemas/finishCategory.ts
+++ b/sanity/schemas/finishCategory.ts
@@ -1,0 +1,70 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'finishCategory',
+  title: 'Finish Category',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Display Title',
+      type: 'string',
+      description: 'e.g. Venetian Plaster',
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      description: 'e.g. venetian-plaster — must match classification category value',
+      options: { source: 'title' },
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: 'sortOrder',
+      title: 'Sort Order',
+      type: 'number',
+      description: 'Controls display order in gallery navigation',
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: 'heroImage',
+      title: 'Category Hero Image',
+      type: 'image',
+      options: { hotspot: true }
+    }),
+    defineField({
+      name: 'shortDescription',
+      title: 'Short Description',
+      type: 'text',
+      rows: 2,
+      description: 'One sentence shown on category card'
+    }),
+    defineField({
+      name: 'tradeDescription',
+      title: 'Trade Description',
+      type: 'text',
+      rows: 4,
+      description: 'Shown on category landing page for trade visitors'
+    }),
+    defineField({
+      name: 'isVisible',
+      title: 'Visible in Gallery',
+      type: 'boolean',
+      initialValue: true
+    }),
+  ],
+  preview: {
+    select: { title: 'title', media: 'heroImage', order: 'sortOrder' },
+    prepare({ title, media, order }) {
+      return { title: `${order}. ${title}`, media }
+    }
+  },
+  orderings: [
+    {
+      title: 'Sort Order',
+      name: 'sortOrderAsc',
+      by: [{ field: 'sortOrder', direction: 'asc' }]
+    }
+  ]
+})

--- a/sanity/schemas/mainSiteSettings.ts
+++ b/sanity/schemas/mainSiteSettings.ts
@@ -1,0 +1,49 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'mainSiteSettings',
+  title: 'Main Site Settings',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'heroImage',
+      title: 'Homepage Hero Image',
+      type: 'reference',
+      to: [{ type: 'portfolioPiece' }],
+      description: 'The portfolio piece whose hero image appears as the full-screen homepage background',
+    }),
+    defineField({
+      name: 'heroHeadline',
+      title: 'Hero Headline',
+      type: 'string',
+      description: 'Main headline on the homepage hero section',
+    }),
+    defineField({
+      name: 'heroSubheadline',
+      title: 'Hero Subheadline',
+      type: 'string',
+      description: 'Subheadline text below the main headline',
+    }),
+    defineField({
+      name: 'featuredTestimonial',
+      title: 'Featured Testimonial',
+      type: 'object',
+      fields: [
+        defineField({ name: 'name', type: 'string', title: 'Client Name' }),
+        defineField({ name: 'quote', type: 'text', title: 'Quote', rows: 3 }),
+        defineField({ name: 'duration', type: 'string', title: 'Duration (e.g. "22-year client")' }),
+        defineField({ name: 'location', type: 'string', title: 'Location' }),
+      ],
+    }),
+    defineField({
+      name: 'neighborhoodStrip',
+      title: 'Neighborhood Strip',
+      type: 'array',
+      of: [{ type: 'string' }],
+      description: 'Neighborhoods displayed in the social proof strip',
+    }),
+    defineField({ name: 'seoTitle', type: 'string', title: 'SEO Title' }),
+    defineField({ name: 'seoDescription', type: 'text', title: 'SEO Description', rows: 2 }),
+  ],
+  preview: { prepare: () => ({ title: 'Main Site Settings' }) },
+})

--- a/sanity/schemas/portfolioPiece.ts
+++ b/sanity/schemas/portfolioPiece.ts
@@ -1,0 +1,468 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'portfolioPiece',
+  title: 'Portfolio Piece',
+  type: 'document',
+  groups: [
+    { name: 'display',  title: 'Display',       default: true },
+    { name: 'project',  title: 'Project' },
+    { name: 'trade',    title: 'Trade Details' },
+    { name: 'room',     title: 'Room & Space' },
+    { name: 'color',    title: 'Color & Light' },
+    { name: 'agent',    title: 'DFA-Agent' },
+    { name: 'tech',     title: 'Technical' },
+  ],
+  fields: [
+    /* ── Display ───────────────────────────────────────────── */
+    defineField({ name: 'title', title: 'Title', type: 'string', group: 'display' }),
+    defineField({ name: 'slug', title: 'Slug', type: 'slug', options: { source: 'title' }, group: 'display' }),
+    defineField({ name: 'subtitle', title: 'Subtitle', type: 'string', group: 'display' }),
+    defineField({
+      name: 'category', title: 'Category', type: 'string', group: 'display',
+      options: {
+        list: [
+          { title: 'Venetian Plaster',    value: 'venetian-plaster' },
+          { title: 'Wall Murals',         value: 'wall-murals' },
+          { title: 'Faux Finishes',       value: 'faux-finishes' },
+          { title: "Trompe l'Oeil",       value: 'trompe-loeil' },
+          { title: 'Decorative Ceilings', value: 'decorative-ceilings' },
+          { title: 'Modello & Stencils',  value: 'modello-stencils' },
+          { title: 'Themed Rooms',            value: 'themed-rooms' },
+          { title: "Children's Rooms",      value: 'childrens-rooms' },
+          { title: 'Skyscapes & Celestial', value: 'skyscapes' },
+          { title: 'Commercial & Public Art', value: 'commercial' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'finishCategory',
+      title: 'Finish Category (Reference)',
+      type: 'reference',
+      to: [{ type: 'finishCategory' }],
+      description: 'Links to the finishCategory document — will replace string category after migration',
+      group: 'display',
+    }),
+    defineField({ name: 'location', title: 'Location', type: 'string', group: 'display' }),
+    defineField({
+      name: 'heroImage', title: 'Hero Image', type: 'image', group: 'display',
+      options: { hotspot: true },
+      fields: [
+        defineField({ name: 'alt', title: 'Alt text', type: 'string' }),
+        defineField({ name: 'caption', title: 'Caption', type: 'string' }),
+      ],
+    }),
+    defineField({
+      name: 'images', title: 'Additional Images', type: 'array', group: 'display',
+      of: [{
+        type: 'image', options: { hotspot: true },
+        fields: [
+          defineField({ name: 'alt', type: 'string', title: 'Alt text' }),
+          defineField({ name: 'caption', type: 'string', title: 'Caption' }),
+        ],
+      }],
+    }),
+    defineField({
+      name: 'orientation', title: 'Orientation', type: 'string', group: 'display',
+      options: { list: ['portrait', 'landscape', 'square'], layout: 'radio' },
+      initialValue: 'portrait',
+    }),
+    defineField({ name: 'description', title: 'Description', type: 'text', rows: 4, group: 'display' }),
+    defineField({ name: 'featuredProject', title: 'Featured Project (legacy)', type: 'string', group: 'display',
+      description: 'Deprecated — use project reference below',
+      hidden: true,
+    }),
+    defineField({
+      name: 'project', title: 'Project', type: 'reference', group: 'display',
+      to: [{ type: 'studioProject' }],
+      description: 'The studio project this piece belongs to',
+    }),
+    defineField({
+      name: 'isProjectAnchor',
+      title: 'Gallery Anchor',
+      type: 'boolean',
+      description: 'This piece represents the project in the gallery grid.',
+      initialValue: false,
+      group: 'project',
+    }),
+    defineField({
+      name: 'showAsCompanion',
+      title: 'Show in Lightbox Strip',
+      type: 'boolean',
+      description: 'Include in the companion thumbnail strip when anchor is opened.',
+      initialValue: true,
+      group: 'project',
+    }),
+    defineField({
+      name: 'companionOrder',
+      title: 'Companion Strip Order',
+      type: 'number',
+      description: 'Position in lightbox strip. Auto-managed by editor.',
+      readOnly: true,
+      group: 'project',
+    }),
+    defineField({
+      name: 'flags', title: 'Flags', type: 'array', of: [{ type: 'string' }], group: 'display',
+      options: {
+        list: [
+          { title: 'Retouch needed', value: 'retouch-needed' },
+          { title: 'Lens flare',     value: 'lens-flare' },
+          { title: 'Working title',  value: 'working-title' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'featured', title: 'Featured', type: 'boolean', group: 'display',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'isFeatured', title: 'Featured Piece', type: 'boolean', group: 'display',
+      description: 'Appears in featured slots on homepage and category hero',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'featuredOrder', title: 'Featured Order', type: 'number', group: 'display',
+      description: 'Display position in featured section (auto-managed)',
+      readOnly: true,
+    }),
+    defineField({
+      name: 'isMishaSelect', title: 'Misha Select', type: 'boolean', group: 'display',
+      description: 'Hand-picked for the curated Misha Select gallery',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'displayOrder', title: 'Display Order', type: 'number', group: 'display',
+      description: 'Lower numbers appear first in gallery grids',
+    }),
+    defineField({
+      name: 'imageClassification', title: 'Image Classification', type: 'array', group: 'display',
+      of: [{ type: 'string' }],
+      description: 'Tag this image for curation workflow',
+      options: {
+        list: [
+          { title: '✅ Portfolio Ready',   value: 'portfolio-ready' },
+          { title: '⭐ Hero Candidate',    value: 'hero-candidate' },
+          { title: '👷 Crew at Work',      value: 'crew-at-work' },
+          { title: '🔴 Before / Demo',     value: 'before' },
+          { title: '🔧 In Progress / WIP', value: 'in-progress' },
+          { title: '🔍 Crop Needed',       value: 'crop-needed' },
+          { title: '📐 Upres Needed',      value: 'upres-needed' },
+          { title: '🎨 PS Edit Needed',    value: 'ps-edit-needed' },
+          { title: '📁 Misc / Reference',  value: 'misc' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'published', title: 'Published', type: 'boolean', group: 'display',
+      initialValue: false,
+    }),
+
+    /* ── Trade Details ─────────────────────────────────────── */
+    defineField({
+      name: 'secondaryCategory', title: 'Secondary Category', type: 'string', group: 'trade',
+      description: 'For images that span multiple finish types',
+      options: {
+        list: [
+          { title: 'Venetian Plaster',      value: 'venetian-plaster' },
+          { title: 'Wall Murals',           value: 'wall-murals' },
+          { title: 'Faux Finishes',         value: 'faux-finishes' },
+          { title: "Trompe l'Oeil",         value: 'trompe-loeil' },
+          { title: 'Decorative Ceilings',   value: 'decorative-ceilings' },
+          { title: 'Modello & Stencils',    value: 'modello-stencils' },
+          { title: 'Themed Rooms',          value: 'themed-rooms' },
+          { title: "Children's Rooms",      value: 'childrens-rooms' },
+          { title: 'Skyscapes & Celestial', value: 'skyscapes' },
+          { title: 'Commercial & Public Art', value: 'commercial' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'tertiaryCategory', title: 'Tertiary Category', type: 'string', group: 'trade',
+      description: 'For images that span multiple finish types',
+      options: {
+        list: [
+          { title: 'Venetian Plaster',      value: 'venetian-plaster' },
+          { title: 'Wall Murals',           value: 'wall-murals' },
+          { title: 'Faux Finishes',         value: 'faux-finishes' },
+          { title: "Trompe l'Oeil",         value: 'trompe-loeil' },
+          { title: 'Decorative Ceilings',   value: 'decorative-ceilings' },
+          { title: 'Modello & Stencils',    value: 'modello-stencils' },
+          { title: 'Themed Rooms',          value: 'themed-rooms' },
+          { title: "Children's Rooms",      value: 'childrens-rooms' },
+          { title: 'Skyscapes & Celestial', value: 'skyscapes' },
+          { title: 'Commercial & Public Art', value: 'commercial' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'projectType', title: 'Project Type', type: 'string', group: 'trade',
+      initialValue: 'residential',
+      options: {
+        list: [
+          { title: 'Residential',          value: 'residential' },
+          { title: 'Commercial / Public',  value: 'commercial' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'finishSubcategory', title: 'Finish Subcategory', type: 'string', group: 'trade',
+      description: 'Subcategory within the finish type',
+      options: {
+        list: [
+          // Venetian & Lime Plaster
+          { title: 'Polished Venetian',    value: 'polished-venetian' },
+          { title: 'Marmorino',            value: 'marmorino' },
+          { title: 'Tadelakt',             value: 'tadelakt' },
+          { title: 'Limewash',             value: 'limewash' },
+          { title: 'Textured Plaster',     value: 'textured-plaster' },
+          // Faux Finishes
+          { title: 'Faux Wood',            value: 'faux-wood' },
+          { title: 'Faux Cabinets',        value: 'faux-cabinets' },
+          { title: 'Marbleizing',          value: 'marbleizing' },
+          { title: 'Decorative Wall',      value: 'decorative-wall' },
+          { title: 'Epoxy Floors',         value: 'epoxy-floors' },
+          { title: 'Faux Brick',           value: 'faux-brick' },
+          { title: 'Gilding & Metallic',   value: 'gilding-metallic' },
+          { title: 'Crackle & Distressed', value: 'crackle-distressed' },
+          { title: 'Faux Stone',           value: 'faux-stone' },
+          { title: 'High-Gloss Lacquer',   value: 'high-gloss-lacquer' },
+          // Wall Murals
+          { title: 'Landscape',            value: 'landscape' },
+          { title: 'Botanical',            value: 'botanical' },
+          { title: 'Chinoiserie',          value: 'chinoiserie' },
+          { title: 'Figurative',           value: 'figurative' },
+          { title: 'Asian-Inspired',       value: 'asian-inspired' },
+          { title: 'Tropical',             value: 'tropical' },
+          { title: 'Powder Room',          value: 'powder-room' },
+          { title: 'Abstract Mural',       value: 'abstract-mural' },
+          { title: 'Classical & Historical', value: 'classical-historical' },
+          // Trompe l'Oeil
+          { title: 'Architectural Illusion', value: 'architectural-illusion' },
+          { title: 'Scenic Illusion',      value: 'scenic-illusion' },
+          { title: 'Grisaille Trompe-l\'Oeil', value: 'grisaille-trompe-loeil' },
+          { title: 'Quadratura',           value: 'quadratura' },
+          { title: 'Still Life in Niche',  value: 'still-life-niche' },
+          // Skyscapes
+          { title: 'Day Sky & Clouds',     value: 'day-sky-clouds' },
+          { title: 'Night Stars & Galaxies', value: 'night-stars-galaxies' },
+          { title: 'Airbrushed Sky',       value: 'airbrushed-sky' },
+          { title: 'Celestial / Cosmic',   value: 'celestial-cosmic' },
+          { title: 'Sunset / Sunrise',     value: 'sunset-sunrise' },
+          // Decorative Ceilings
+          { title: 'Sky Ceiling',          value: 'sky-ceiling' },
+          { title: 'Medallion',            value: 'medallion' },
+          { title: 'Coffered',             value: 'coffered' },
+          { title: 'Gilded / Metallic',    value: 'gilded-metallic' },
+          { title: "Trompe l'Oeil Dome",   value: 'trompe-oeil-dome' },
+          { title: 'Ornamental Relief',    value: 'ornamental-relief' },
+          { title: 'Scrollwork & Ornament', value: 'scrollwork-ornament' },
+          // Modello & Stencils
+          { title: 'Allover Pattern',      value: 'allover-pattern' },
+          { title: 'Medallion Stencil',    value: 'medallion-stencil' },
+          { title: 'Border Stencil',       value: 'border-stencil' },
+          { title: 'Floor Stencil',        value: 'floor-stencil' },
+          // Themed Rooms
+          { title: 'Residential Theme',    value: 'residential-theme' },
+          { title: 'Commercial Theme',     value: 'commercial-theme' },
+          { title: 'Jerusalem',            value: 'jerusalem' },
+          { title: 'Tropical Pool',        value: 'tropical-pool' },
+          { title: 'Law Firm',             value: 'law-firm' },
+          { title: 'Sealife',              value: 'sealife' },
+          { title: 'Wine Cellar / Vineyard', value: 'wine-cellar' },
+          { title: 'Home Theater',         value: 'home-theater' },
+          // Children's Rooms
+          { title: 'Whimsical',            value: 'whimsical' },
+          { title: 'Nursery',              value: 'nursery' },
+          { title: 'Adventure',            value: 'adventure' },
+          { title: 'Fantasy',              value: 'fantasy' },
+          { title: 'Educational',          value: 'educational' },
+          // Commercial & Public Art
+          { title: 'Lobby & Reception',    value: 'lobby-reception' },
+          { title: 'Restaurant & Hospitality', value: 'restaurant-hospitality' },
+          { title: 'Religious & Institutional', value: 'religious-institutional' },
+          { title: 'Retail & Corporate',   value: 'retail-corporate' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'finishTechnique', title: 'Finish Technique', type: 'string', group: 'trade',
+      description: 'Specific technique within category (e.g., Grassello, Burnished, Marmorino, Fresco)',
+    }),
+    defineField({
+      name: 'finishVariant', title: 'Finish Variant', type: 'string', group: 'trade',
+      description: 'Specific sub-type e.g. polished-venetian, chinoiserie, aged-fresco',
+    }),
+    defineField({
+      name: 'tradeTags', title: 'Trade Search Tags', type: 'array', group: 'trade',
+      of: [{ type: 'string' }],
+      description: 'Keywords a designer or builder would search',
+    }),
+    defineField({
+      name: 'isDetailCrop', title: 'Detail Crop', type: 'boolean', group: 'trade',
+      description: 'True if this is a close-up texture/technique shot',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'mishaComment', title: "Misha's Note", type: 'text', rows: 2, group: 'trade',
+      description: "Voice note captured during Misha's image review",
+    }),
+
+    /* ── Room & Space ──────────────────────────────────────── */
+    defineField({
+      name: 'roomType', title: 'Room Type', type: 'string', group: 'room',
+      options: {
+        list: [
+          'living-room', 'dining-room', 'bedroom', 'primary-bedroom',
+          'bathroom', 'powder-room', 'kitchen', 'library', 'study',
+          'office', 'entryway', 'foyer', 'hallway', 'staircase',
+          'great-room', 'family-room', 'media-room', 'wine-cellar',
+          'sunroom', 'conservatory', 'loggia', 'outdoor',
+          'commercial', 'hospitality', 'ceiling-only',
+          'architectural-detail', 'unknown'
+        ],
+      },
+    }),
+    defineField({
+      name: 'surfaceOrientation', title: 'Surface Orientation', type: 'string', group: 'room',
+      options: {
+        list: ['wall', 'ceiling', 'floor', 'architectural-element', 'full-room', 'detail'],
+      },
+    }),
+    defineField({
+      name: 'roomScale', title: 'Room Scale', type: 'string', group: 'room',
+      options: { list: ['intimate', 'medium', 'grand', 'unknown'] },
+    }),
+
+    /* ── Color & Light ─────────────────────────────────────── */
+    defineField({
+      name: 'colorTemperature', title: 'Color Temperature', type: 'string', group: 'color',
+      options: {
+        list: ['warm', 'cool', 'neutral', 'dramatic', 'ethereal'],
+      },
+    }),
+    defineField({
+      name: 'colorPalette', title: 'Color Palette', type: 'array', group: 'color',
+      of: [{ type: 'string' }],
+      description: '2-4 dominant colors in plain english',
+    }),
+
+    /* ── DFA-Agent Classification ─────────────────────────── */
+    defineField({
+      name: 'agentClassificationVersion', title: 'Taxonomy Version', type: 'string', group: 'agent',
+      description: 'Taxonomy version used for classification (e.g., v1.0)',
+      readOnly: true,
+    }),
+    defineField({
+      name: 'agentClassificationConfidence', title: 'Classification Confidence', type: 'string', group: 'agent',
+      options: {
+        list: [
+          { title: 'HIGH — auto-accept',    value: 'HIGH' },
+          { title: 'MEDIUM — spot-check',   value: 'MEDIUM' },
+          { title: 'REVIEW — human required', value: 'REVIEW' },
+        ],
+      },
+      readOnly: true,
+    }),
+    defineField({
+      name: 'agentClassificationModels', title: 'Models Used', type: 'array', group: 'agent',
+      of: [{ type: 'string' }],
+      description: 'Vision models used and their agreement status',
+      readOnly: true,
+    }),
+    defineField({
+      name: 'qualityScore', title: 'Quality Score', type: 'number', group: 'agent',
+      description: 'Composite image quality score 0-100',
+      readOnly: true,
+    }),
+    defineField({
+      name: 'qualityFlags', title: 'Quality Flags', type: 'array', group: 'agent',
+      of: [{ type: 'string' }],
+      options: {
+        list: [
+          { title: 'Needs Upscaling',  value: 'NEEDS_UPSCALING' },
+          { title: 'Needs Sharpening', value: 'NEEDS_SHARPENING' },
+          { title: 'Needs Lighting',   value: 'NEEDS_LIGHTING' },
+          { title: 'Human Content',    value: 'HUMAN_CONTENT' },
+          { title: 'Hero Candidate',   value: 'HERO_CANDIDATE' },
+          { title: 'Reject',           value: 'REJECT' },
+        ],
+      },
+      readOnly: true,
+    }),
+    defineField({
+      name: 'referenceAnchors', title: 'Reference Anchors', type: 'array', group: 'agent',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({ name: 'taxonomyNodeId', title: 'Taxonomy Node', type: 'string' }),
+          defineField({ name: 'referenceImageId', title: 'Reference Image', type: 'string' }),
+          defineField({ name: 'confidence', title: 'Confidence', type: 'number' }),
+        ],
+      }],
+      description: 'Taxonomy nodes and reference images supporting classification',
+      readOnly: true,
+    }),
+    defineField({
+      name: 'humanReviewRequired', title: 'Human Review Required', type: 'boolean', group: 'agent',
+      description: 'True if model disagreement or quality flag triggered review',
+      initialValue: false,
+      readOnly: true,
+    }),
+    defineField({
+      name: 'humanReviewStatus', title: 'Human Review Status', type: 'string', group: 'agent',
+      options: {
+        list: [
+          { title: 'Pending',   value: 'PENDING' },
+          { title: 'Approved',  value: 'APPROVED' },
+          { title: 'Rejected',  value: 'REJECTED' },
+          { title: 'Corrected', value: 'CORRECTED' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'humanReviewNotes', title: 'Human Review Notes', type: 'text', rows: 3, group: 'agent',
+      description: 'Reviewer observations and corrections',
+    }),
+
+    /* ── Technical ─────────────────────────────────────────── */
+    defineField({
+      name: 'assetId', title: 'Asset ID', type: 'string', group: 'tech',
+    }),
+    defineField({
+      name: 'sourceFile', title: 'Source Filename', type: 'string', group: 'tech',
+      description: 'Original filename from classification — used for deduplication',
+      readOnly: true,
+    }),
+    defineField({
+      name: 'importBatch', title: 'Import Batch', type: 'string', group: 'tech',
+      description: 'Migration batch identifier — used for deduplication',
+      readOnly: true,
+    }),
+    defineField({
+      name: 'enrichmentConfidence', title: 'Enrichment Confidence', type: 'number', group: 'tech',
+      description: 'AI confidence score from enrichment pass (0-1)',
+      readOnly: true,
+    }),
+    defineField({
+      name: 'archived', title: 'Archived', type: 'boolean', group: 'tech',
+      description: 'Hide from site without deleting. Archived pieces remain recoverable.',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'archivedAt', title: 'Archived At', type: 'datetime', group: 'tech',
+      hidden: ({ document }) => !document?.archived,
+      readOnly: true,
+    }),
+    defineField({
+      name: 'archivedReason', title: 'Archive Reason', type: 'string', group: 'tech',
+      hidden: ({ document }) => !document?.archived,
+      description: 'Why this piece was archived — e.g. "duplicate", "low quality", "similar to IMG_3749"',
+    }),
+  ],
+  preview: {
+    select: { title: 'title', subtitle: 'assetId', media: 'heroImage', published: 'published' },
+    prepare({ title, subtitle, media, published }) {
+      return { title: `${published ? '' : '⬜ '}${title}`, subtitle, media }
+    },
+  },
+})

--- a/sanity/schemas/processPage.ts
+++ b/sanity/schemas/processPage.ts
@@ -1,0 +1,59 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'processPage',
+  title: 'Process Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'seo',
+      title: 'SEO',
+      type: 'object',
+      fields: [
+        defineField({ name: 'metaTitle', type: 'string', title: 'Meta Title' }),
+        defineField({ name: 'metaDescription', type: 'text', title: 'Meta Description', rows: 3 }),
+      ],
+    }),
+    defineField({ name: 'heroHeadline', type: 'string', title: 'Hero Headline' }),
+    defineField({ name: 'heroSubtext', type: 'string', title: 'Hero Subtext' }),
+    defineField({ name: 'introHeading', type: 'string', title: 'Intro Section Heading' }),
+    defineField({ name: 'introText', type: 'text', title: 'Intro Text', rows: 4 }),
+    defineField({ name: 'aboutHeading', type: 'string', title: 'About Section Heading' }),
+    defineField({
+      name: 'aboutParagraphs',
+      type: 'array',
+      title: 'About Paragraphs',
+      of: [{ type: 'text' }],
+    }),
+    defineField({
+      name: 'processSteps',
+      title: 'Process Steps',
+      type: 'array',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({ name: 'step', type: 'string', title: 'Step Number' }),
+          defineField({ name: 'name', type: 'string', title: 'Step Name' }),
+          defineField({ name: 'desc', type: 'text', title: 'Description', rows: 3 }),
+        ],
+        preview: { select: { title: 'name', subtitle: 'step' } },
+      }],
+    }),
+    defineField({
+      name: 'faqs',
+      title: 'Process FAQs',
+      type: 'array',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({ name: 'question', type: 'string', title: 'Question', validation: (Rule) => Rule.required() }),
+          defineField({ name: 'answer', type: 'text', title: 'Answer', rows: 4, validation: (Rule) => Rule.required() }),
+        ],
+        preview: { select: { title: 'question' } },
+      }],
+    }),
+    defineField({ name: 'ctaHeadline', type: 'string', title: 'CTA Headline' }),
+    defineField({ name: 'ctaBody', type: 'text', title: 'CTA Body', rows: 3 }),
+  ],
+  preview: { prepare: () => ({ title: 'Process Page' }) },
+})

--- a/sanity/schemas/servicePage.ts
+++ b/sanity/schemas/servicePage.ts
@@ -1,0 +1,144 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'servicePage',
+  title: 'Service Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'slug',
+      title: 'URL Slug',
+      type: 'slug',
+      description: 'URL path segment, e.g. "venetian-lime-plaster"',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'categoryId',
+      title: 'Category ID',
+      type: 'string',
+      description: 'Maps to portfolioPiece.category value (e.g. "wall-murals")',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'title',
+      title: 'Display Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'h1',
+      title: 'Page H1',
+      type: 'string',
+    }),
+    defineField({
+      name: 'cardDescription',
+      title: 'Card Description',
+      type: 'text',
+      rows: 2,
+      description: 'One-liner shown on the services hub page',
+    }),
+    defineField({
+      name: 'seo',
+      title: 'SEO',
+      type: 'object',
+      fields: [
+        defineField({ name: 'metaTitle', type: 'string', title: 'Meta Title' }),
+        defineField({ name: 'metaDescription', type: 'text', title: 'Meta Description', rows: 3 }),
+      ],
+    }),
+    defineField({
+      name: 'intro',
+      title: 'Intro Section',
+      type: 'object',
+      fields: [
+        defineField({ name: 'heading', type: 'string', title: 'Heading' }),
+        defineField({
+          name: 'paragraphs',
+          type: 'array',
+          title: 'Paragraphs',
+          of: [{ type: 'text' }],
+        }),
+      ],
+    }),
+    defineField({
+      name: 'process',
+      title: 'Process Section',
+      type: 'object',
+      fields: [
+        defineField({ name: 'heading', type: 'string', title: 'Heading' }),
+        defineField({
+          name: 'steps',
+          type: 'array',
+          title: 'Steps',
+          of: [{
+            type: 'object',
+            fields: [
+              defineField({ name: 'name', type: 'string', title: 'Step Name' }),
+              defineField({ name: 'desc', type: 'text', title: 'Description', rows: 3 }),
+            ],
+            preview: { select: { title: 'name' } },
+          }],
+        }),
+      ],
+    }),
+    defineField({
+      name: 'trust',
+      title: 'Trust Section',
+      type: 'object',
+      fields: [
+        defineField({ name: 'heading', type: 'string', title: 'Heading' }),
+        defineField({
+          name: 'points',
+          type: 'array',
+          title: 'Trust Points',
+          of: [{ type: 'string' }],
+        }),
+      ],
+    }),
+    defineField({
+      name: 'extraFaqs',
+      title: 'FAQs',
+      type: 'array',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({ name: 'question', type: 'string', title: 'Question', validation: (Rule) => Rule.required() }),
+          defineField({ name: 'answer', type: 'text', title: 'Answer', rows: 4, validation: (Rule) => Rule.required() }),
+        ],
+        preview: { select: { title: 'question' } },
+      }],
+    }),
+    defineField({
+      name: 'relatedServices',
+      title: 'Related Services',
+      type: 'array',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({ name: 'slug', type: 'string', title: 'Service Slug' }),
+          defineField({ name: 'label', type: 'string', title: 'Display Label' }),
+        ],
+        preview: { select: { title: 'label' } },
+      }],
+    }),
+    defineField({
+      name: 'areaContext',
+      title: 'Area Context Line',
+      type: 'text',
+      rows: 2,
+      description: 'Area mention for the bottom of the page',
+    }),
+    defineField({
+      name: 'sortOrder',
+      title: 'Sort Order',
+      type: 'number',
+      description: 'Display order on the services hub page',
+    }),
+  ],
+  preview: {
+    select: { title: 'title' },
+  },
+  orderings: [
+    { title: 'Sort Order', name: 'sortOrder', by: [{ field: 'sortOrder', direction: 'asc' }] },
+  ],
+})

--- a/sanity/schemas/servicesHubPage.ts
+++ b/sanity/schemas/servicesHubPage.ts
@@ -1,0 +1,49 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'servicesHubPage',
+  title: 'Services Hub Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'seo',
+      title: 'SEO',
+      type: 'object',
+      fields: [
+        defineField({ name: 'metaTitle', type: 'string', title: 'Meta Title' }),
+        defineField({ name: 'metaDescription', type: 'text', title: 'Meta Description', rows: 3 }),
+      ],
+    }),
+    defineField({ name: 'heroHeadline', type: 'string', title: 'Hero Headline' }),
+    defineField({ name: 'heroSubtext', type: 'text', title: 'Hero Subtext', rows: 2 }),
+    defineField({ name: 'introText', type: 'text', title: 'Intro Paragraph', rows: 4 }),
+    defineField({
+      name: 'trustHeading',
+      type: 'string',
+      title: 'Trust Section Heading',
+    }),
+    defineField({
+      name: 'trustPoints',
+      type: 'array',
+      title: 'Trust Points',
+      of: [{ type: 'string' }],
+    }),
+    defineField({ name: 'processHeading', type: 'string', title: 'Process Section Heading' }),
+    defineField({
+      name: 'hubFaqs',
+      title: 'Hub FAQs',
+      type: 'array',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({ name: 'question', type: 'string', title: 'Question', validation: (Rule) => Rule.required() }),
+          defineField({ name: 'answer', type: 'text', title: 'Answer', rows: 4, validation: (Rule) => Rule.required() }),
+        ],
+        preview: { select: { title: 'question' } },
+      }],
+    }),
+    defineField({ name: 'ctaHeadline', type: 'string', title: 'CTA Headline' }),
+    defineField({ name: 'ctaBody', type: 'text', title: 'CTA Body', rows: 3 }),
+  ],
+  preview: { prepare: () => ({ title: 'Services Hub Page' }) },
+})

--- a/sanity/schemas/siteGlobals.ts
+++ b/sanity/schemas/siteGlobals.ts
@@ -1,0 +1,78 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'siteGlobals',
+  title: 'Site Globals',
+  type: 'document',
+  fields: [
+    defineField({ name: 'siteName', type: 'string', title: 'Site Name' }),
+    defineField({ name: 'tagline', type: 'string', title: 'Tagline' }),
+    defineField({ name: 'phone', type: 'string', title: 'Phone Number' }),
+    defineField({ name: 'phoneHref', type: 'string', title: 'Phone Href (tel: link)' }),
+    defineField({ name: 'email', type: 'string', title: 'Email' }),
+    defineField({
+      name: 'address',
+      title: 'Business Address',
+      type: 'object',
+      fields: [
+        defineField({ name: 'city', type: 'string', title: 'City' }),
+        defineField({ name: 'state', type: 'string', title: 'State' }),
+        defineField({ name: 'country', type: 'string', title: 'Country' }),
+      ],
+    }),
+    defineField({
+      name: 'socialProofNeighborhoods',
+      title: 'Social Proof Neighborhoods',
+      type: 'array',
+      of: [{ type: 'string' }],
+      description: 'Neighborhood names used for social proof strips',
+    }),
+    defineField({
+      name: 'social',
+      title: 'Social Links',
+      type: 'object',
+      fields: [
+        defineField({ name: 'instagram', type: 'url', title: 'Instagram' }),
+        defineField({ name: 'facebook', type: 'url', title: 'Facebook' }),
+        defineField({ name: 'pinterest', type: 'url', title: 'Pinterest' }),
+        defineField({ name: 'googleMaps', type: 'url', title: 'Google Maps' }),
+      ],
+    }),
+    defineField({
+      name: 'processSteps',
+      title: 'Global Process Steps',
+      type: 'array',
+      description: 'The 4-step process used across multiple pages',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({ name: 'step', type: 'string', title: 'Step Number' }),
+          defineField({ name: 'name', type: 'string', title: 'Step Name' }),
+          defineField({ name: 'desc', type: 'text', title: 'Description', rows: 3 }),
+        ],
+        preview: { select: { title: 'name', subtitle: 'step' } },
+      }],
+    }),
+    defineField({
+      name: 'inquireRoomTypes',
+      title: 'Inquire Form — Room Types',
+      type: 'array',
+      of: [{ type: 'string' }],
+      description: 'Room type options for the inquiry form dropdown',
+    }),
+    defineField({
+      name: 'inquireTimeframes',
+      title: 'Inquire Form — Timeframes',
+      type: 'array',
+      of: [{
+        type: 'object',
+        fields: [
+          defineField({ name: 'value', type: 'string', title: 'Value' }),
+          defineField({ name: 'label', type: 'string', title: 'Label' }),
+        ],
+        preview: { select: { title: 'label' } },
+      }],
+    }),
+  ],
+  preview: { prepare: () => ({ title: 'Site Globals' }) },
+})

--- a/sanity/schemas/studioProject.ts
+++ b/sanity/schemas/studioProject.ts
@@ -1,0 +1,199 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'studioProject',
+  title: 'Studio Project',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Project Title',
+      type: 'string',
+      validation: Rule => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: { source: 'title' },
+      validation: Rule => Rule.required(),
+    }),
+    defineField({
+      name: 'category',
+      title: 'Primary Category',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Venetian Plaster',      value: 'venetian-plaster' },
+          { title: 'Wall Murals',           value: 'wall-murals' },
+          { title: 'Faux Finishes',         value: 'faux-finishes' },
+          { title: "Trompe l'Oeil",         value: 'trompe-loeil' },
+          { title: 'Decorative Ceilings',   value: 'decorative-ceilings' },
+          { title: 'Modello & Stencils',    value: 'modello-stencils' },
+          { title: 'Themed Rooms',          value: 'themed-rooms' },
+          { title: "Children's Rooms",      value: 'childrens-rooms' },
+          { title: 'Skyscapes & Celestial', value: 'skyscapes' },
+          { title: 'Commercial & Public Art', value: 'commercial' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+      rows: 3,
+      description: 'Brief project description for gallery display',
+    }),
+    defineField({
+      name: 'heroImage',
+      title: 'Hero Image',
+      type: 'image',
+      options: { hotspot: true },
+      description: 'Primary image representing this project. If empty, uses the first piece\'s heroImage.',
+      fields: [
+        defineField({ name: 'alt', title: 'Alt text', type: 'string' }),
+      ],
+    }),
+    defineField({
+      name: 'pieces',
+      title: 'Project Pieces',
+      type: 'array',
+      of: [{ type: 'reference', to: [{ type: 'portfolioPiece' }] }],
+      description: 'Portfolio pieces belonging to this project, in display order',
+    }),
+    defineField({
+      name: 'anchorPiece',
+      title: 'Gallery Anchor Piece',
+      type: 'reference',
+      to: [{ type: 'portfolioPiece' }],
+      description: 'The piece that represents this project in the gallery grid.',
+    }),
+    defineField({
+      name: 'location',
+      title: 'Location',
+      type: 'string',
+    }),
+    defineField({
+      name: 'projectType',
+      title: 'Project Type',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Residential', value: 'residential' },
+          { title: 'Commercial / Public', value: 'commercial' },
+        ],
+      },
+      initialValue: 'residential',
+    }),
+    defineField({
+      name: 'testimonial',
+      title: 'Client Testimonial',
+      type: 'object',
+      description: 'A quote from the client for this project. All fields optional; leave blank to render no testimonial.',
+      fields: [
+        defineField({
+          name: 'quote',
+          title: 'Quote',
+          type: 'text',
+          rows: 4,
+          description: 'The client\'s words, verbatim.',
+        }),
+        defineField({
+          name: 'attribution',
+          title: 'Attribution Name',
+          type: 'string',
+          description: 'e.g. "Anna Adkinson"; leave blank for anonymous.',
+        }),
+        defineField({
+          name: 'role',
+          title: 'Role / Relationship',
+          type: 'string',
+          description: 'e.g. "Homeowner, River Oaks" or "22-year client".',
+        }),
+        defineField({
+          name: 'date',
+          title: 'Date Given',
+          type: 'date',
+          description: 'Optional — when the quote was provided.',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'displayOrder',
+      title: 'Display Order',
+      type: 'number',
+      description: 'Lower numbers appear first',
+    }),
+    defineField({
+      name: 'isFeatured',
+      title: 'Featured Project',
+      type: 'boolean',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'isMishaSelect',
+      title: 'Misha Select',
+      type: 'boolean',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'published',
+      title: 'Published',
+      type: 'boolean',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'source',
+      title: 'Record Source',
+      type: 'string',
+      description: 'Provenance of this project record. Set automatically on creation; do not edit manually unless correcting a mis-classified record.',
+      options: {
+        list: [
+          { title: 'Operator authored',            value: 'operator-authored' },
+          { title: 'Auto classifier',              value: 'auto-classifier' },
+          { title: 'Migrated from finishCategory', value: 'migrated-from-finishCategory' },
+        ],
+      },
+    }),
+    defineField({
+      name: 'mergedInto',
+      title: 'Merged Into',
+      type: 'reference',
+      to: [{ type: 'studioProject' }],
+      readOnly: true,
+    }),
+    defineField({
+      name: 'mergedAt',
+      title: 'Merged At',
+      type: 'datetime',
+      readOnly: true,
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'category',
+      media: 'heroImage',
+      published: 'published',
+    },
+    prepare({ title, subtitle, media, published }) {
+      return {
+        title: `${published ? '' : '⬜ '}${title}`,
+        subtitle: subtitle?.replace(/-/g, ' '),
+        media,
+      }
+    },
+  },
+  orderings: [
+    {
+      title: 'Display Order',
+      name: 'displayOrderAsc',
+      by: [{ field: 'displayOrder', direction: 'asc' }],
+    },
+    {
+      title: 'Category',
+      name: 'categoryAsc',
+      by: [{ field: 'category', direction: 'asc' }],
+    },
+  ],
+})


### PR DESCRIPTION
## Summary
- 12 schemas now available in mishacreations.com/studio
- Page content: homepage, about, FAQ, process, services, areas, blog, globals
- Portfolio: pieces, categories, projects
- Misha can browse and edit image metadata, titles, descriptions directly

## Test plan
- [ ] Navigate to mishacreations.com/studio
- [ ] Verify all 12 document types appear in sidebar
- [ ] Edit a portfolio piece title and verify it saves
- [ ] Edit FAQ page and verify changes appear on /faq

Generated with [Claude Code](https://claude.com/claude-code)