### PR TITLE
Suppress visible main-site image overlays

### DIFF
--- a/src/app/areas/[slug]/page.tsx
+++ b/src/app/areas/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { NEIGHBORHOOD_MAP, NEIGHBORHOODS, NEIGHBORHOOD_CONTENT, FINISH_SURFACES } from '@/lib/constants'
+import { NEIGHBORHOOD_MAP, NEIGHBORHOODS, NEIGHBORHOOD_CONTENT, FINISH_SURFACES, SUPPRESS_VISIBLE_IMAGE_TITLES } from '@/lib/constants'
 import { getPiecesByCategories, getMishaSelectPieces, getAreaPage, getAllAreaSlugs, getAllServicePages } from '@/lib/queries'
 import { SanityImage } from '@/components/SanityImage'
 import { FaqAccordion } from '@/components/FaqAccordion'
@@ -144,9 +144,11 @@ export default async function AreaPage({ params }: PageProps) {
                     alt={piece.heroImage?.alt || `${piece.title} - decorative finish in ${name} by Misha Creations`}
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
-                  <div className="absolute bottom-0 left-0 right-0 p-5">
-                    <p className="font-editorial text-lg text-white">{piece.title}</p>
-                  </div>
+                  {!SUPPRESS_VISIBLE_IMAGE_TITLES && (
+                    <div className="absolute bottom-0 left-0 right-0 p-5">
+                      <p className="font-editorial text-lg text-white">{piece.title}</p>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import { SanityImage } from '@/components/SanityImage'
 import { NeighborhoodStrip } from '@/components/NeighborhoodStrip'
 import { CtaSection } from '@/components/CtaSection'
 import { JsonLd } from '@/components/JsonLd'
-import { COPY } from '@/lib/constants'
+import { COPY, SUPPRESS_VISIBLE_IMAGE_TITLES } from '@/lib/constants'
 
 export const metadata: Metadata = {
   alternates: {
@@ -157,10 +157,12 @@ export default async function HomePage() {
                     />
                   )}
                   <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
-                  <div className="absolute bottom-0 left-0 right-0 p-5">
-                    <p className="font-editorial text-xl text-white">{service.title}</p>
-                    <p className="font-body text-sm text-white/70 mt-1">Explore &rarr;</p>
-                  </div>
+                  {!SUPPRESS_VISIBLE_IMAGE_TITLES && (
+                    <div className="absolute bottom-0 left-0 right-0 p-5">
+                      <p className="font-editorial text-xl text-white">{service.title}</p>
+                      <p className="font-body text-sm text-white/70 mt-1">Explore &rarr;</p>
+                    </div>
+                  )}
                 </Link>
               ))}
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import { SanityImage } from '@/components/SanityImage'
 import { NeighborhoodStrip } from '@/components/NeighborhoodStrip'
 import { CtaSection } from '@/components/CtaSection'
 import { JsonLd } from '@/components/JsonLd'
-import { COPY, SUPPRESS_VISIBLE_IMAGE_TITLES } from '@/lib/constants'
+import { COPY } from '@/lib/constants'
 
 export const metadata: Metadata = {
   alternates: {
@@ -145,24 +145,27 @@ export default async function HomePage() {
                 <Link
                   key={service.categoryId}
                   href={service.servicePath}
-                  className="group relative aspect-[4/5] rounded-lg overflow-hidden shadow-md"
+                  className="group block"
                 >
-                  {service.heroImage && (
-                    <SanityImage
-                      image={service.heroImage}
-                      fill
-                      sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                      className="object-cover group-hover:scale-105 transition-transform duration-500"
-                      alt={`${service.title} — Misha Creations Houston`}
-                    />
-                  )}
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
-                  {!SUPPRESS_VISIBLE_IMAGE_TITLES && (
-                    <div className="absolute bottom-0 left-0 right-0 p-5">
-                      <p className="font-editorial text-xl text-white">{service.title}</p>
-                      <p className="font-body text-sm text-white/70 mt-1">Explore &rarr;</p>
-                    </div>
-                  )}
+                  <div className="relative aspect-[4/5] rounded-lg overflow-hidden shadow-md mb-4">
+                    {service.heroImage && (
+                      <SanityImage
+                        image={service.heroImage}
+                        fill
+                        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                        className="object-cover group-hover:scale-105 transition-transform duration-500"
+                        alt={`${service.title} — Misha Creations Houston`}
+                      />
+                    )}
+                  </div>
+                  <div className="px-1">
+                    <p className="font-editorial text-xl text-cream group-hover:text-gold transition-colors">
+                      {service.title}
+                    </p>
+                    <p className="font-body text-xs uppercase tracking-widest text-gold mt-1.5">
+                      View Service &rarr;
+                    </p>
+                  </div>
                 </Link>
               ))}
             </div>

--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { FINISH_MAP, FINISH_SURFACES, FINISH_DESCRIPTIONS, SERVICE_ENRICHMENT } from '@/lib/constants'
+import { FINISH_MAP, FINISH_SURFACES, FINISH_DESCRIPTIONS, SERVICE_ENRICHMENT, SUPPRESS_VISIBLE_IMAGE_TITLES } from '@/lib/constants'
 import { getPiecesByCategory, getFinishCategory, getServicePage, getAllServiceSlugs } from '@/lib/queries'
 import { SanityImage } from '@/components/SanityImage'
 import { FaqAccordion } from '@/components/FaqAccordion'
@@ -191,12 +191,14 @@ export default async function ServicePage({ params }: PageProps) {
                     alt={piece.heroImage?.alt || `${piece.title} - ${title} by Misha Creations Houston`}
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
-                  <div className="absolute bottom-0 left-0 right-0 p-5">
-                    <p className="font-editorial text-lg text-white">{piece.title}</p>
-                    {piece.location && (
-                      <p className="font-body text-sm text-white/70 mt-1">{piece.location}</p>
-                    )}
-                  </div>
+                  {!SUPPRESS_VISIBLE_IMAGE_TITLES && (
+                    <div className="absolute bottom-0 left-0 right-0 p-5">
+                      <p className="font-editorial text-lg text-white">{piece.title}</p>
+                      {piece.location && (
+                        <p className="font-body text-sm text-white/70 mt-1">{piece.location}</p>
+                      )}
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { FINISH_SURFACES, SERVICE_CARD_DESCRIPTIONS, SERVICES_HUB_FAQS, PROCESS_STEPS, COPY, SUPPRESS_VISIBLE_IMAGE_TITLES } from '@/lib/constants'
+import { FINISH_SURFACES, SERVICE_CARD_DESCRIPTIONS, SERVICES_HUB_FAQS, PROCESS_STEPS, COPY } from '@/lib/constants'
 import { getPiecesByCategory, getServicesHubPage, getAllServicePages, getSiteGlobals } from '@/lib/queries'
 import { SanityImage } from '@/components/SanityImage'
 import { CtaSection } from '@/components/CtaSection'
@@ -96,26 +96,32 @@ export default async function ServicesPage() {
               <Link
                 key={service.slug}
                 href={`/services/${service.slug}`}
-                className="group relative aspect-[3/4] rounded-lg overflow-hidden shadow-md"
+                className="group block"
               >
-                {heroImage && (
-                  <SanityImage
-                    image={heroImage}
-                    fill
-                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
-                    className="object-cover group-hover:scale-105 transition-transform duration-500"
-                  />
-                )}
-                {!heroImage && <div className="absolute inset-0 bg-ink" />}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
-                {!SUPPRESS_VISIBLE_IMAGE_TITLES && (
-                  <div className="absolute bottom-0 left-0 right-0 p-5">
-                    <h3 className="font-editorial text-lg text-white">{service.title}</h3>
-                    {service.cardDescription && (
-                      <p className="font-body text-sm text-white/70 mt-1">{service.cardDescription}</p>
-                    )}
-                  </div>
-                )}
+                <div className="relative aspect-[3/4] rounded-lg overflow-hidden shadow-md mb-4">
+                  {heroImage && (
+                    <SanityImage
+                      image={heroImage}
+                      fill
+                      sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+                      className="object-cover group-hover:scale-105 transition-transform duration-500"
+                    />
+                  )}
+                  {!heroImage && <div className="absolute inset-0 bg-ink" />}
+                </div>
+                <div className="px-1">
+                  <h3 className="font-editorial text-lg text-cream group-hover:text-gold transition-colors">
+                    {service.title}
+                  </h3>
+                  {service.cardDescription && (
+                    <p className="font-body text-sm text-mist/80 mt-1.5 leading-snug">
+                      {service.cardDescription}
+                    </p>
+                  )}
+                  <p className="font-body text-xs uppercase tracking-widest text-gold mt-2">
+                    Explore &rarr;
+                  </p>
+                </div>
               </Link>
             ))}
           </div>

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { FINISH_SURFACES, SERVICE_CARD_DESCRIPTIONS, SERVICES_HUB_FAQS, PROCESS_STEPS, COPY } from '@/lib/constants'
+import { FINISH_SURFACES, SERVICE_CARD_DESCRIPTIONS, SERVICES_HUB_FAQS, PROCESS_STEPS, COPY, SUPPRESS_VISIBLE_IMAGE_TITLES } from '@/lib/constants'
 import { getPiecesByCategory, getServicesHubPage, getAllServicePages, getSiteGlobals } from '@/lib/queries'
 import { SanityImage } from '@/components/SanityImage'
 import { CtaSection } from '@/components/CtaSection'
@@ -108,12 +108,14 @@ export default async function ServicesPage() {
                 )}
                 {!heroImage && <div className="absolute inset-0 bg-ink" />}
                 <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
-                <div className="absolute bottom-0 left-0 right-0 p-5">
-                  <h3 className="font-editorial text-lg text-white">{service.title}</h3>
-                  {service.cardDescription && (
-                    <p className="font-body text-sm text-white/70 mt-1">{service.cardDescription}</p>
-                  )}
-                </div>
+                {!SUPPRESS_VISIBLE_IMAGE_TITLES && (
+                  <div className="absolute bottom-0 left-0 right-0 p-5">
+                    <h3 className="font-editorial text-lg text-white">{service.title}</h3>
+                    {service.cardDescription && (
+                      <p className="font-body text-sm text-white/70 mt-1">{service.cardDescription}</p>
+                    )}
+                  </div>
+                )}
               </Link>
             ))}
           </div>

--- a/src/components/PortfolioCard.tsx
+++ b/src/components/PortfolioCard.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import type { PortfolioPiece } from '@/lib/queries'
 import { SanityImage } from '@/components/SanityImage'
-import { FINISH_SURFACES } from '@/lib/constants'
+import { FINISH_SURFACES, SUPPRESS_VISIBLE_IMAGE_TITLES } from '@/lib/constants'
 
 interface PortfolioCardProps {
   piece: PortfolioPiece
@@ -36,18 +36,20 @@ export function PortfolioCard({ piece, showCategory, sizes, priority }: Portfoli
         </span>
       )}
 
-      {/* Info overlay */}
-      <div className="absolute bottom-0 left-0 right-0 p-5">
-        {showCategory && finish && (
-          <p className="font-body text-[10px] uppercase tracking-[0.16em] text-gold mb-1.5">
-            {finish.title}
-          </p>
-        )}
-        <p className="font-editorial text-lg text-white leading-snug">{piece.title}</p>
-        {piece.location && (
-          <p className="font-body text-sm text-white/65 mt-1">{piece.location}</p>
-        )}
-      </div>
+      {/* Info overlay — suppressed by SUPPRESS_VISIBLE_IMAGE_TITLES (CR-MC-MAIN-SITE-SUPPRESS-FEATURED-IMAGE-TITLES-001) */}
+      {!SUPPRESS_VISIBLE_IMAGE_TITLES && (
+        <div className="absolute bottom-0 left-0 right-0 p-5">
+          {showCategory && finish && (
+            <p className="font-body text-[10px] uppercase tracking-[0.16em] text-gold mb-1.5">
+              {finish.title}
+            </p>
+          )}
+          <p className="font-editorial text-lg text-white leading-snug">{piece.title}</p>
+          {piece.location && (
+            <p className="font-body text-sm text-white/65 mt-1">{piece.location}</p>
+          )}
+        </div>
+      )}
     </Link>
   )
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,6 +15,13 @@ export const FONTS = {
   body:      "'Jost', sans-serif",
 } as const
 
+// CR-MC-MAIN-SITE-SUPPRESS-FEATURED-IMAGE-TITLES-001: hides absolute-positioned
+// text overlays on top of card images (portfolio cards, service-index tiles,
+// service-detail grids, area-page grids, homepage Selected Works). Does not
+// affect page H1/H2/H3 headings, hero text, alt text, or card body text
+// rendered below images. Flip to `false` to restore overlay labels.
+export const SUPPRESS_VISIBLE_IMAGE_TITLES = true
+
 export interface FinishSurface {
   /** URL slug — used in /services/{slug} route */
   slug: string


### PR DESCRIPTION
## Summary
- Suppresses visible image-title overlays on main-site image/card surfaces (portfolio cards, homepage Selected Works tiles, service-index tiles, service-detail portfolio grids, area-page grids).
- Keeps page titles, section headings, and hero copy intact.
- Preserves SEO, `alt` text, OpenGraph/Twitter metadata, JSON-LD structured data.
- Restores service navigation labels below images on homepage Selected Works and `/services` index — labels appear in clean editorial card-body positions, never overlaid on the image surface.

## Design principle
- Images remain clean artwork surfaces.
- True service labels appear **below** images as editorial / navigation framing — title + minimal CTA, never positioned over the image.
- No text overlaid on images. No image-metadata captions. No AI/DFA-derived image titles.
- Card-body titles below images on `/recent-projects` (project cards) remain as authored — already correct, untouched by this PR.

## Files changed
- `src/lib/constants.ts` — adds `SUPPRESS_VISIBLE_IMAGE_TITLES` flag with docblock (one-line flip to restore overlays on remaining suppressed surfaces).
- `src/components/PortfolioCard.tsx` — gates the absolute-positioned info-overlay (finish eyebrow, piece.title, location) behind the flag.
- `src/app/page.tsx` — homepage Selected Works grid: image moved into clean wrapper, service title + `View Service →` CTA rendered below the image, not overlaid.
- `src/app/services/page.tsx` — services-index grid: image moved into clean wrapper, service H3 title + authored `cardDescription` + `Explore →` CTA rendered below the image, not overlaid.
- `src/app/services/[slug]/page.tsx` — service-detail portfolio grid: piece.title/location overlay gated behind the flag.
- `src/app/areas/[slug]/page.tsx` — area-page portfolio grid: piece.title overlay gated behind the flag.

Two commits on this branch (suppression + design refinement):
- `0874271` fix(main-site): suppress visible image-title overlays on card surfaces
- `99e59b8` refine(main-site): restore service nav labels below images (no overlay)

## Build result
- ✅ Vercel preview deployment: **Ready** (`dpl_AMGxTJu7YenBfVEYxCf1s9dNvjTs`)
- ✅ Local `npm run build`: clean — 587 static pages generated, no type or render errors
- ✅ Curl-level smoke checks across 9 routes: 0 overlay divs, all H1/H2/H3 headings intact, alt attribute counts preserved
- ⚠️ `npm run lint` blocked by pre-existing infra: ESLint can't resolve transitive dep `fdir`. Not caused by this PR; lint never executed on any changed file. Recommend a separate `npm install` to repair `node_modules` at your convenience.

## Preview URLs
- Per-commit (immutable): https://misha-website-amyhximlj-ray-richardsons-projects-4591755e.vercel.app
- Branch alias (auto-updates to latest commit on branch): https://misha-website-git-feat-6e9356-ray-richardsons-projects-4591755e.vercel.app

> Note: preview URLs return 401 to unauthenticated requests (Vercel Deployment Protection). Open in an authenticated browser to review.

## Evidence
Screenshots: `/Users/rayrichardson/ControlHub/03_Misha_Creations/Portfolio-Curation/CR-MC-MAIN-SITE-SUPPRESS-FEATURED-IMAGE-TITLES-001/evidence/screenshots/`
- 12 baseline screenshots (suppression, 9 desktop + 3 mobile)
- 6 refinement screenshots under `refinement/` subdir (R1–R6: homepage, services index, service-detail control, recent-projects control, mobile homepage, mobile services)

CR record: `CR-MC-MAIN-SITE-SUPPRESS-FEATURED-IMAGE-TITLES-001`. Classification: `UX_VISIBILITY_GAP` with `DATA_INTEGRITY` undertone.

## Negative confirmations
- ✅ No Sanity writes (no `patch_document`, no `publish_documents`, no `unpublish_documents`, no mutation of any kind).
- ✅ No Sanity reads added or modified (no `sanityClient.fetch` calls touched, no GROQ queries changed, no Sanity schemas changed).
- ✅ No SEO / alt / metadata changes (`generateMetadata`, `JsonLd`, `alt` attributes, OpenGraph, Twitter cards, canonical URLs all unmodified).
- ✅ No page-heading suppression (every H1, H2, H3 verified intact via curl smoke).
- ✅ No hero text changes.
- ✅ No image-asset mutation.
- ✅ No production deploy — preview only.
- ✅ Held stash `stash@{0}` (in-flight CR-MC-CATEGORY-CLASSIFICATION-POLICY-001 and CR-MC-FAQ-CMS-WIRE-001 work) untouched and remains available for restoration after merge.

## Test plan
- [ ] Open branch-alias preview URL in authenticated browser
- [ ] Verify homepage Selected Works: clean images + service title + `View Service →` below each tile
- [ ] Verify `/services`: clean images + service H3 + card description + `Explore →` below each tile
- [ ] Verify `/services/[slug]`, `/areas/[slug]`, `/portfolio`, `/recent-projects`, `/projects/[slug]` show clean images with no overlay text
- [ ] Verify page H1s, hero copy, section H2s, body copy, alt text all intact
- [ ] Verify mobile viewport renders the same pattern cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)