### PR TITLE
Refine hero sections with editorial image framing

### DIFF
--- a/src/app/areas/[slug]/page.tsx
+++ b/src/app/areas/[slug]/page.tsx
@@ -100,22 +100,28 @@ export default async function AreaPage({ params }: PageProps) {
     <>
       <JsonLd data={localBusinessSchema} />
 
-      {/* Hero */}
-      <section className="relative min-h-[55vh] flex items-center justify-center overflow-hidden bg-ink">
-        {pieces[0]?.heroImage && (
-          <div className="absolute inset-0">
-            <SanityImage image={pieces[0].heroImage} fill priority sizes="100vw" className="object-cover opacity-40" />
-          </div>
-        )}
-        <div className="relative z-10 text-center px-5 max-w-4xl mx-auto pt-20">
-          <h1 className="font-display text-[38px] leading-[48px] md:text-[54px] md:leading-[64px] text-white mb-4">
+      {/* Hero — editorial band (text only) */}
+      <section className="bg-ink pt-32 pb-12 md:pt-40 md:pb-16">
+        <div className="text-center px-5 max-w-4xl mx-auto">
+          <h1 className="font-display text-[38px] leading-[48px] md:text-[54px] md:leading-[64px] text-cream mb-4">
             {h1}
           </h1>
-          <p className="font-body text-lg text-white/85 max-w-2xl mx-auto">
+          <p className="font-body text-lg text-mist max-w-2xl mx-auto">
             Trusted by {name} homeowners for over 25 years
           </p>
         </div>
       </section>
+
+      {/* Hero image — contained, clean (full opacity, no fade) */}
+      {pieces[0]?.heroImage && (
+        <section className="bg-ink pb-8">
+          <div className="max-w-5xl mx-auto px-5">
+            <div className="relative w-full aspect-[16/9] overflow-hidden rounded-xl">
+              <SanityImage image={pieces[0].heroImage} fill priority sizes="(max-width: 1024px) 100vw, 1024px" className="object-cover" />
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Description */}
       {content && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -101,20 +101,13 @@ export default async function HomePage() {
     <>
       <JsonLd data={localBusinessSchema} />
 
-      {/* Hero */}
-      <section className="relative min-h-[70vh] flex items-center justify-center overflow-hidden">
-        {heroImage && (
-          <div className="absolute inset-0">
-            <SanityImage image={heroImage} fill priority sizes="100vw" className="object-cover" />
-            <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/20 to-black/50" />
-          </div>
-        )}
-        {!heroImage && <div className="absolute inset-0 bg-ink" />}
-        <div className="relative z-10 text-left px-5 md:px-12 max-w-4xl mr-auto pt-20">
-          <h1 className="font-display text-[42px] leading-[52px] md:text-[60px] md:leading-[72px] text-white mb-6">
+      {/* Hero — editorial band (text only, no image overlay) */}
+      <section className="bg-ink pt-32 pb-12 md:pt-40 md:pb-16">
+        <div className="text-left px-5 md:px-12 max-w-4xl mr-auto">
+          <h1 className="font-display text-[42px] leading-[52px] md:text-[60px] md:leading-[72px] text-cream mb-6">
             {headline}
           </h1>
-          <p className="font-body text-lg md:text-xl text-white/90 mb-10 max-w-2xl leading-relaxed">
+          <p className="font-body text-lg md:text-xl text-mist mb-10 max-w-2xl leading-relaxed">
             {subheadline}
           </p>
           <a
@@ -125,6 +118,15 @@ export default async function HomePage() {
           </a>
         </div>
       </section>
+
+      {/* Hero image — full-bleed, clean (no overlay text) */}
+      {heroImage && (
+        <section className="bg-ink">
+          <div className="relative w-full aspect-[4/5] md:aspect-[21/9] max-h-[62vh] overflow-hidden">
+            <SanityImage image={heroImage} fill priority sizes="100vw" className="object-cover" />
+          </div>
+        </section>
+      )}
 
       <NeighborhoodStrip />
 

--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -109,24 +109,28 @@ export default async function ServicePage({ params }: PageProps) {
     <>
       <JsonLd data={serviceSchema} />
 
-      {/* Hero */}
-      <section className="relative min-h-[60vh] flex items-center justify-center overflow-hidden">
-        {heroImage && (
-          <div className="absolute inset-0">
-            <SanityImage image={heroImage} fill priority sizes="100vw" className="object-cover" />
-            <div className="absolute inset-0 bg-gradient-to-b from-black/50 via-black/30 to-black/60" />
-          </div>
-        )}
-        {!heroImage && <div className="absolute inset-0 bg-ink" />}
-        <div className="relative z-10 text-center px-5 max-w-4xl mx-auto pt-20">
-          <h1 className="font-display text-[38px] leading-[48px] md:text-[54px] md:leading-[64px] text-white mb-4">
+      {/* Hero — editorial band (text only) */}
+      <section className="bg-ink pt-32 pb-12 md:pt-40 md:pb-16">
+        <div className="text-center px-5 max-w-4xl mx-auto">
+          <h1 className="font-display text-[38px] leading-[48px] md:text-[54px] md:leading-[64px] text-cream mb-4">
             {h1}
           </h1>
-          <p className="font-body text-lg text-white/85 max-w-2xl mx-auto">
+          <p className="font-body text-lg text-mist max-w-2xl mx-auto">
             By Misha Creations &middot; 25+ Years of Artistic Excellence
           </p>
         </div>
       </section>
+
+      {/* Hero image — contained, clean */}
+      {heroImage && (
+        <section className="bg-ink pb-8">
+          <div className="max-w-5xl mx-auto px-5">
+            <div className="relative w-full aspect-[16/9] overflow-hidden rounded-xl">
+              <SanityImage image={heroImage} fill priority sizes="(max-width: 1024px) 100vw, 1024px" className="object-cover" />
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Description */}
       <section className="py-16 md:py-20 bg-warm">


### PR DESCRIPTION
## Summary
- Moves homepage hero text off artwork into an editorial text band, with the hero image rendered as a clean full-bleed visual below the text
- Moves service-detail hero text off artwork into editorial text bands, with a clean contained `aspect-[16/9]` image below
- Moves area-page hero text off artwork into editorial text bands, with a clean full-opacity `aspect-[16/9]` image below (removes the prior `opacity-40` legibility fade)
- Preserves all H1 / subheadline / CTA copy verbatim
- Preserves SEO, `alt` text, OpenGraph / Twitter metadata, JSON-LD structured data, and canonical URLs
- Does not touch Sanity (no reads added/modified, no writes, no schema or query changes)
- Does not change image assets
- Does not address deferred PortfolioCard / piece-grid gradient cleanup (intentionally out of scope; tracked from prior audit)

Applies the in-codebase "editorial hero stack" pattern already established on `/projects/[slug]` to three additional surfaces: `/`, `/services/[slug]`, and `/areas/[slug]`.

## Changed files
- `src/app/page.tsx` — homepage hero restructured into solid `bg-ink` editorial band (H1 + subheadline + CTA) followed by clean image section at `aspect-[4/5] md:aspect-[21/9] max-h-[62vh]`
- `src/app/services/[slug]/page.tsx` — service-detail hero restructured into solid editorial band (H1 + "By Misha Creations · 25+ Years…" subtitle) followed by contained `max-w-5xl` image section at `aspect-[16/9] rounded-xl`
- `src/app/areas/[slug]/page.tsx` — area-page hero restructured into solid editorial band (H1 + "Trusted by [name] homeowners…" subheadline) followed by contained `max-w-5xl` image section at `aspect-[16/9] rounded-xl` at full opacity

Commit: `a13dca67e4875ffc6e15c4e16c5867aeac5dc74d`
Diff: +46 / -34 across 3 files (rendering-layer only — JSX structure + Tailwind utility classes)

## Preview URLs
- Per-commit (immutable): https://misha-website-4yghj2sma-ray-richardsons-projects-4591755e.vercel.app
- Branch alias (auto-updates to latest commit on branch): https://misha-website-git-feat-984a4d-ray-richardsons-projects-4591755e.vercel.app

> Note: preview URLs return 401 to unauthenticated requests (Vercel Deployment Protection). Open in an authenticated browser to review.

## Design notes
- **Homepage mobile crop is acceptable for the current hero image.** Current Sanity-rendered hero composes well at `aspect-[4/5]`. A future landscape-composed hero swap may require aspect-ratio adjustment (candidates: `aspect-[3/4]`, `aspect-square`, or fixed `h-[60vh]`).
- **Area-page hero images now display at full opacity** (previously faded to `opacity-40` to legibilize overlay text). Weak or low-resolution area hero images may become more visible. Memorial verified acceptable; other area pages (River Oaks, Tanglewood, etc.) should be sanity-checked in browser since each pulls `pieces[0].heroImage` from a featured-category query.
- **Homepage desktop `max-h-[62vh]` clamp is intentional.** On standard 16:9 desktop viewports the cap kicks in before the literal `aspect-[21/9]` height, and `object-cover` performs a slight vertical crop — preserves cinematic widescreen feel while preventing excessive vertical real estate on shorter monitors.
- **Deferred PortfolioCard / piece-grid gradients remain out of scope.** The `bg-gradient-to-t from-black/70 via-black/5 to-transparent` on `PortfolioCard.tsx:30` and similar gradients on `services/[slug]/page.tsx:193` and `areas/[slug]/page.tsx:146` are tracked from prior CR-MC-MAIN-SITE-EDITORIAL-IMAGE-FRAMING-001 audit and intentionally not touched in this PR.

## Evidence
Screenshots: `/Users/rayrichardson/ControlHub/03_Misha_Creations/Portfolio-Curation/CR-MC-MAIN-SITE-HERO-EDITORIAL-FRAMING-001/evidence/screenshots/`
- 7 PNGs covering homepage / service detail / area page at desktop + mobile, plus `/projects/[slug]` as the control surface (already in editorial-stack pattern)

CR record: `CR-MC-MAIN-SITE-HERO-EDITORIAL-FRAMING-001`. Classification: `UX_VISIBILITY_GAP`.

## Negative confirmations
- ✅ No Sanity writes (no `patch_document`, no `publish_documents`, no `unpublish_documents`, no mutation of any kind)
- ✅ No Sanity reads added or modified (no `sanityClient.fetch` calls touched, no GROQ queries changed, no Sanity schemas changed)
- ✅ No SEO / `alt` / metadata changes (`generateMetadata`, `JsonLd`, `alt` attributes, OpenGraph, Twitter cards, canonical URLs all unmodified)
- ✅ No copy changes — every H1, subheadline, and CTA string preserved verbatim
- ✅ No image-asset mutation
- ✅ No production deploy — preview only
- ✅ Held stash `stash@{0}` (in-flight CR-MC-CATEGORY-CLASSIFICATION-POLICY-001 + CR-MC-FAQ-CMS-WIRE-001 work) untouched and available for restoration after merge
- ✅ Deferred PortfolioCard / piece-grid gradient cleanup intentionally NOT included in this PR

## Test plan
- [ ] Open branch-alias preview URL in authenticated browser
- [ ] Verify `/` (homepage): H1/subheadline/CTA in editorial band, hero image below with no text overlay, image feels premium/cinematic at desktop + mobile
- [ ] Verify `/services/luxury-wall-murals` (and one other service detail): H1/subtitle in editorial band, clean `aspect-[16/9]` image below
- [ ] Verify `/areas/memorial` (and one other area page): H1/subheadline in editorial band, full-opacity `aspect-[16/9]` image below — confirm image quality acceptable now that opacity fade is removed
- [ ] Verify control surface `/projects/[slug]` is unchanged from current production
- [ ] Verify page H1s, hero copy, section H2s, body copy, alt text all intact site-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)