### PR TITLE
Replace Themed Rooms gallery section cards

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { getFeaturedPieces, getPiecesByCategory } from '@/lib/queries'
-import { FINISH_SURFACES, COPY } from '@/lib/constants'
+import { getFeaturedPieces, getPiecesByCategory, getPiecesBySlugs } from '@/lib/queries'
+import { FINISH_SURFACES, COPY, GALLERY_SECTION_OVERRIDES } from '@/lib/constants'
 import { PortfolioCard } from '@/components/PortfolioCard'
 import { CtaSection } from '@/components/CtaSection'
 import { JsonLd } from '@/components/JsonLd'
@@ -26,7 +26,10 @@ export const metadata: Metadata = {
 export default async function GalleryPage() {
   const [featured, ...categoryResults] = await Promise.all([
     getFeaturedPieces(6),
-    ...FINISH_SURFACES.map((f) => getPiecesByCategory(f.categoryId, 6)),
+    ...FINISH_SURFACES.map((f) => {
+      const override = GALLERY_SECTION_OVERRIDES[f.categoryId]
+      return override ? getPiecesBySlugs(override) : getPiecesByCategory(f.categoryId, 6)
+    }),
   ])
 
   const gallerySchema = {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -188,6 +188,31 @@ export const SERVICE_CARD_DESCRIPTIONS: Record<string, string> = {
   'modello-stencils': 'Elegant stencil designs for walls, ceilings, and architectural details.',
 }
 
+/* ─── /gallery section overrides ──────────────────────────────────────────
+ * CR-MC-MAIN-SITE-PORTFOLIO-IMAGE-REPLACEMENT-001
+ *
+ * Per-categoryId explicit piece-slug override for the /gallery page's
+ * per-finish-category sections. When an entry exists for a categoryId,
+ * /gallery renders exactly those slugs in that order instead of running
+ * getPiecesByCategory(). Detail pages, document fields, taxonomy, and any
+ * other gallery route (/portfolio listing, /services/[slug], /areas/[slug],
+ * /recent-projects, /projects/[slug]) continue to use the default
+ * category-driven query unchanged.
+ *
+ * To remove the override and restore default category behavior for a
+ * section, delete its entry here.
+ */
+export const GALLERY_SECTION_OVERRIDES: Record<string, string[]> = {
+  'themed-rooms': [
+    'hand-painted-grapevine-mural-wrapping-walls-and-angled-ceiling-of-residential-wine-cellar-with-t',
+    'hand-painted-space-mural-ceiling-in-childrens-bedroom-featuring-star-wars-star-destroyers-agains',
+    'hand-painted-blue-marlin-sealife-mural-on-commercial-wall-galveston-themescape-with-teal-ocean-b',
+    'hand-painted-childrens-bedroom-mural-with-waterfall-landscape-and-realistic-leopard-on-rocky-cli',
+    'early-america-themescape-mural-dear-and-waterfall',
+    'hand-painted-chinoiserie-bedroom-mural-on-celadon-plaster-ground-with-white-blossom-trees-and-co',
+  ],
+}
+
 /* ─── Service page enrichment content (003A — venetian plaster first) ─── */
 export interface ServiceEnrichment {
   intro: { heading: string; paragraphs: string[] }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -79,6 +79,21 @@ export async function getPiecesByCategory(category: string, limit = 6): Promise<
   `, { category, limit })
 }
 
+/** Fetch published, non-archived portfolio pieces by an explicit ordered slug list.
+ *  Used by /gallery section overrides (GALLERY_SECTION_OVERRIDES) to pin specific
+ *  pieces for a given section. Returns pieces in the SAME order as the input slugs,
+ *  silently dropping any slug that does not resolve to a published, non-archived piece.
+ */
+export async function getPiecesBySlugs(slugs: string[]): Promise<PortfolioPiece[]> {
+  if (!slugs.length) return []
+  const pieces = await sanityClient.fetch<PortfolioPiece[]>(`
+    *[_type == "portfolioPiece" && published == true && coalesce(archived, false) != true && slug.current in $slugs]
+    { ${PIECE_FIELDS} }
+  `, { slugs })
+  const bySlug = new Map(pieces.map((p) => [p.slug.current, p]))
+  return slugs.map((s) => bySlug.get(s)).filter(Boolean) as PortfolioPiece[]
+}
+
 /** Pieces by multiple categories with offset (for unique neighborhood pages) */
 export async function getPiecesByCategories(categories: string[], perCategory = 2, offset = 0): Promise<PortfolioPiece[]> {
   const results = await Promise.all(


### PR DESCRIPTION
## Summary
- Replaces only **slots 5 and 6** in the `/gallery` page **Themed Rooms** section with two approved portfolio pieces
- Uses a code-only `GALLERY_SECTION_OVERRIDES` mechanism — per-categoryId explicit slug pinning, scoped exclusively to the `/gallery` per-finish-category renderer
- Leaves portfolio detail pages unchanged (all 4 detail pages in the mapping remain reachable with unchanged H1s and image fields)
- Leaves Sanity documents unchanged — no portfolioPiece mutation of any kind
- Does not modify portfolio `heroImage.asset` / `heroImage.alt` / `heroImage.hotspot` / `heroImage.caption` on any document
- Does not modify titles, slugs, SEO metadata / OpenGraph / Twitter / JSON-LD / canonical, alt text, `category`, `isFeatured`, `isMishaSelect`, `displayOrder`, `archived`, `published`, or image assets

## Changed files (3, +46 / −3)
- `src/lib/constants.ts` — added `GALLERY_SECTION_OVERRIDES: Record<string, string[]>` with a single `themed-rooms` entry (6 pinned slugs) + explanatory docblock referencing this CR
- `src/lib/queries.ts` — added `getPiecesBySlugs(slugs)` helper using the same `PIECE_FIELDS` projection as siblings; preserves input order; silently drops slugs that don't resolve to a published, non-archived piece
- `src/app/gallery/page.tsx` — per-section data fetch now uses the override if `GALLERY_SECTION_OVERRIDES[f.categoryId]` exists, otherwise the existing `getPiecesByCategory(f.categoryId, 6)`

Single commit: `75412743c766e2d7dd20e373a169de904fac5231`

## Replacement mapping

**Current slot 5 removed from `/gallery` Themed Rooms section:**
`/portfolio/mottled-silver-gray-venetian-plaster-on-octagonal-tray-ceiling-with-dark-wood-crown-molding-in-p`

**Replacement slot 5:**
`/portfolio/early-america-themescape-mural-dear-and-waterfall`

**Current slot 6 removed from `/gallery` Themed Rooms section:**
`/portfolio/antiqued-glazed-cream-cabinetry-with-carved-acanthus-corbels-framing-arched-travertine-backsplas`

**Replacement slot 6:**
`/portfolio/hand-painted-chinoiserie-bedroom-mural-on-celadon-plaster-ground-with-white-blossom-trees-and-co`

Slots 1–4 in the Themed Rooms section are unchanged. All other `/gallery` sections continue to use `getPiecesByCategory()` (no override entries for those categoryIds).

## Verification
- ✅ `npm run build` passed (clean rebuild after `.next` purge — all routes generated, no errors)
- ✅ Vercel preview deployment Ready (`dpl_HkxDaWZT33nN21YUwpE33QhKDYZa`, target=preview, status=success)
- ✅ Local smoke against the exact pushed commit `7541274` passed
- ✅ `/gallery` Themed Rooms renders all six override slugs in the approved order
- ✅ Current #1 (`mottled-silver-gray-…`) and Current #2 (`antiqued-glazed-…`) hrefs absent from the `/gallery` Themed Rooms section
- ✅ All four portfolio detail pages return HTTP `200` and retain unchanged H1s:
  - `/portfolio/mottled-silver-gray-…` → "Custom Themed Interior — Great Room"
  - `/portfolio/antiqued-glazed-cream-cabinetry-…` → "Custom Themed Interior — Kitchen"
  - `/portfolio/early-america-themescape-mural-dear-and-waterfall` → "Custom Decorative Finish"
  - `/portfolio/hand-painted-chinoiserie-bedroom-mural-…` → "Custom Wall Mural"
- ✅ `/portfolio` 308-redirect to `/gallery` behavior unchanged (pre-existing, not introduced by this CR)
- ✅ No broken images, no 404s
- ✅ No Sanity operations (only read-only diagnostic queries during Phases A–C; zero mutation tools invoked)
- ✅ No portfolio hero-image changes on any document
- ✅ No titles, slugs, SEO metadata, alt text, or taxonomy changes

## Preview URLs
- Per-commit (immutable): https://misha-website-6ypbejx9c-ray-richardsons-projects-4591755e.vercel.app
- Branch alias (auto-tracks head): https://misha-website-git-feat-ffd7b1-ray-richardsons-projects-4591755e.vercel.app

**Note:** Preview is `401`-protected from unauthenticated CLI curl due to Vercel Deployment Protection. This is expected for this project (same protection as all prior main-site previews this quarter). Local smoke against the exact pushed commit and Vercel build success are the basis for PR acceptance; visually review the branch-alias URL in your authenticated browser before merge.

## Evidence
Evidence path: `/Users/rayrichardson/ControlHub/03_Misha_Creations/Portfolio-Curation/CR-MC-MAIN-SITE-PORTFOLIO-IMAGE-REPLACEMENT-001/evidence/`
- `findings.json` — Phase A–C diagnostic (original Sanity-write path now retracted)
- `scope-correction.md` — Ray's clarification + retraction of the prior Sanity-write proposal
- `mapping-and-validation.md` — comprehensive before/after mapping, files changed, validation, negative confirmations, reversibility note
- `screenshots/01-gallery-desktop-post-patch.png` — `/gallery` desktop full-page after patch
- `screenshots/02-gallery-mobile-post-patch.png` — `/gallery` mobile full-page after patch
- `screenshots/03-control-replacement-1-detail.png` — Replacement #1 detail page (control: unchanged)
- `screenshots/04-control-current-1-detail.png` — Current #1 detail page (control: still reachable, unchanged)

## Reversibility
Remove the `themed-rooms` entry from `GALLERY_SECTION_OVERRIDES` (or delete the constant entirely). The `/gallery` Themed Rooms section returns to the default `getPiecesByCategory('themed-rooms', 6) | order(displayOrder asc) [0...6]` behavior in one edit.

## Test plan
- [ ] Open branch-alias preview URL in authenticated browser
- [ ] Scroll to `/gallery` Themed Rooms section — confirm 6 cards, slots 5 and 6 are the Replacement pieces
- [ ] Click each replacement card — confirms navigation to the replacement detail URL (not the current/old URL)
- [ ] Open each of the 4 detail pages directly — confirm all 4 still render correctly with their existing H1s and images
- [ ] Spot-check other `/gallery` sections (Venetian Plaster, Faux Finishes, etc.) — confirm unchanged
- [ ] Spot-check `/recent-projects`, `/projects/early-america-themescape`, homepage — confirm unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)